### PR TITLE
Resolve issue when bots are despawned

### DIFF
--- a/Components/Bot Components/SAINComponent.cs
+++ b/Components/Bot Components/SAINComponent.cs
@@ -201,6 +201,7 @@ namespace SAIN.Components
             Destroy(Hearing);
             Destroy(Talk);
             Destroy(Decision);
+            Destroy(Cover.CoverFinder);
             Destroy(Cover);
             Destroy(FlashLight);
             Destroy(SelfActions);

--- a/Components/Bot Controller Components/Classes/BotSpawnController.cs
+++ b/Components/Bot Controller Components/Classes/BotSpawnController.cs
@@ -79,7 +79,6 @@ namespace SAIN.Components.BotController
                     SAINBotDictionary.Remove(bot.ProfileId);
                     if (bot.TryGetComponent<SAINComponent>(out var component))
                     {
-                        component.BotOwner.LeaveData.OnLeave -= RemoveBot;
                         component.Dispose();
                     }
                 }


### PR DESCRIPTION
- Make sure to clean up the CoverFinder component off bot objects
- Don't need to remove the LeaveData.OnLeave hook, as that object gets cleaned up already on bot despawn