### PR TITLE
Fix spinning bots, extract exceptions and constant firemode switching

### DIFF
--- a/Components/Bot Components/Layers/SAIN Extract/ExtractAction.cs
+++ b/Components/Bot Components/Layers/SAIN Extract/ExtractAction.cs
@@ -105,7 +105,7 @@ namespace SAIN.Layers
                     ReCalcPathTimer = Time.time + 4f;
                     if (NoSprint)
                     {
-                        BotOwner.Mover.GoToPoint(point, true, 0.5f, false, false);
+                        BotOwner.Mover?.GoToPoint(point, true, 0.5f, false, false);
                     }
                     else
                     {

--- a/Components/Bot Components/Old/NavigationPointClass.cs
+++ b/Components/Bot Components/Old/NavigationPointClass.cs
@@ -93,7 +93,7 @@ namespace SAIN.Classes
                         {
                             reachDist = BotOwner.Settings.FileSettings.Move.REACH_DIST;
                         }
-                        BotOwner.Mover.GoToByWay(Path.corners, reachDist, Vector3.zero);
+                        BotOwner.Mover?.GoToByWay(Path.corners, reachDist, Vector3.zero);
 
                         return Path.status;
                     }
@@ -115,7 +115,7 @@ namespace SAIN.Classes
                     {
                         reachDist = BotOwner.Settings.FileSettings.Move.REACH_DIST;
                     }
-                    BotOwner.Mover.GoToByWay(Path.corners, reachDist, Vector3.zero);
+                    BotOwner.Mover?.GoToByWay(Path.corners, reachDist, Vector3.zero);
                     return true;
                 }
             }
@@ -138,7 +138,7 @@ namespace SAIN.Classes
                     bool start = NavPath.status == NavMeshPathStatus.PathComplete || !MustHavePath;
                     if (NavPath.corners.Length > 1 && start)
                     {
-                        BotOwner.Mover.Stop();
+                        BotOwner.Mover?.Stop();
                         var movePath = GetPath(NavPath.corners);
                         ReachDistance = reachDist > 0 ? reachDist : 0.5f;
                         ActivePath = movePath;
@@ -289,7 +289,7 @@ namespace SAIN.Classes
 
         public bool BotIsComeTo()
         {
-            return BotOwner.Mover.IsComeTo(ReachDistance, false);
+            return BotOwner.Mover?.IsComeTo(ReachDistance, false) == true;
         }
 
         public bool BotIsAtPoint(bool Sqr = true, float reachDist = -1f)

--- a/Components/Bot Components/SubComponents/Cover/CoverClass.cs
+++ b/Components/Bot Components/SubComponents/Cover/CoverClass.cs
@@ -206,6 +206,11 @@ namespace SAIN.Classes
         {
             get
             {
+                if (BotOwner?.Mover == null)
+                {
+                    return false;
+                }
+
                 var point = CoverInUse;
                 return point != null && (point.Position - BotOwner.Mover.CurPathLastPoint).sqrMagnitude < 1f;
             }

--- a/Components/Bot Components/SubComponents/Decision/DecisionClass.cs
+++ b/Components/Bot Components/SubComponents/Decision/DecisionClass.cs
@@ -150,7 +150,7 @@ namespace SAIN.Classes
                 return false;
             }
             bool CheckTime = timeChangeDec < 5f;
-            bool Moving = BotOwner.Mover.RealDestPoint != Vector3.one && BotOwner.Mover.DirDestination.magnitude > 2f;
+            bool Moving = BotOwner.Mover?.RealDestPoint != Vector3.one && BotOwner.Mover?.DirDestination.magnitude > 2f;
             return Running && Moving && CheckTime;
         }
 

--- a/Components/Bot Components/SubComponents/Enemy/EnemyController.cs
+++ b/Components/Bot Components/SubComponents/Enemy/EnemyController.cs
@@ -30,34 +30,15 @@ namespace SAIN.Classes
                 ClearEnemies();
             }
 
-            // If the current enemy is AI, but no longer has a BotOwner or is ourselves, reset it
-            if (Enemy?.EnemyPlayer != null && Enemy.EnemyPlayer.IsAI == true && (Enemy?.EnemyPlayer.AIData?.BotOwner == null || Enemy.EnemyPlayer.AIData.BotOwner.ProfileId == BotOwner.ProfileId))
-            {
-                Enemy = null;
-            }
-
-            // If our current enemy no longer exists, clean up
-            if (Enemy?.EnemyPlayer == null)
-            {
-                Enemy = null;
-            }
-
-            // For extra sanity, if the GoalEnemy is AI, and its BotOwner is null, or itself, reset that too
-            if (BotOwner.Memory.GoalEnemy?.Person?.IsAI == true && 
-                (BotOwner.Memory.GoalEnemy?.Person?.AIData?.BotOwner == null || BotOwner.Memory.GoalEnemy.Person.AIData.BotOwner.ProfileId == BotOwner.ProfileId))
-            {
-                BotOwner.Memory.GoalEnemy = null;
-            }
-
             var goalEnemy = BotOwner.Memory.GoalEnemy;
-            if (goalEnemy?.Person != null && goalEnemy.Person.HealthController.IsAlive)
+            if (IsValidEnemy(goalEnemy))
             {
                 AddEnemy(goalEnemy.Person);
             }
             else
             {
                 goalEnemy = BotOwner.Memory.LastEnemy;
-                if (goalEnemy?.Person != null && goalEnemy.Person.HealthController.IsAlive)
+                if (IsValidEnemy(goalEnemy))
                 {
                     AddEnemy(goalEnemy.Person);
                 }
@@ -66,6 +47,31 @@ namespace SAIN.Classes
                     Enemy = null;
                 }
             }
+        }
+
+        private bool IsValidEnemy(GClass475 goalEnemy)
+        {
+            if (goalEnemy?.Person == null)
+            {
+                return false;
+            }
+
+            if (goalEnemy.Person.IsAI && (goalEnemy.Person.AIData?.BotOwner == null || goalEnemy.Person.AIData.BotOwner.BotState != EBotState.Active))
+            {
+                return false;
+            }
+
+            if (goalEnemy.Person.IsAI && goalEnemy.Person.AIData.BotOwner.ProfileId == BotOwner.ProfileId)
+            {
+                return false;
+            }
+
+            if (!goalEnemy.Person.HealthController.IsAlive)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public void AddEnemy(IAIDetails person)

--- a/Components/Bot Components/SubComponents/Enemy/EnemyController.cs
+++ b/Components/Bot Components/SubComponents/Enemy/EnemyController.cs
@@ -109,8 +109,17 @@ namespace SAIN.Classes
                 foreach (string id in Enemies.Keys)
                 {
                     var enemy = Enemies[id];
-                    if (enemy == null || enemy.EnemyPlayer == null || enemy.EnemyPlayer.AIData?.BotOwner == null || enemy.EnemyPlayer.AIData.BotOwner.ProfileId == BotOwner.ProfileId ||
-                        enemy.EnemyPlayer?.HealthController?.IsAlive == false)
+
+                    // Common checks between PMC and bots
+                    if (enemy == null || enemy.EnemyPlayer == null || enemy.EnemyPlayer.HealthController?.IsAlive == false)
+                    {
+                        EnemyIDsToRemove.Add(id);
+                    }
+                    // Checks specific to bots
+                    else if (enemy.EnemyPlayer.IsAI && (
+                        enemy.EnemyPlayer.AIData?.BotOwner == null || 
+                        enemy.EnemyPlayer.AIData.BotOwner.ProfileId == BotOwner.ProfileId || 
+                        enemy.EnemyPlayer.AIData.BotOwner.BotState != EBotState.Active))
                     {
                         EnemyIDsToRemove.Add(id);
                     }

--- a/Components/Bot Components/SubComponents/Enemy/EnemyController.cs
+++ b/Components/Bot Components/SubComponents/Enemy/EnemyController.cs
@@ -30,14 +30,21 @@ namespace SAIN.Classes
                 ClearEnemies();
             }
 
-            // If our current enemy no longer exists, clean up
-            if (Enemy?.EnemyPlayer == null || Enemy?.EnemyPlayer.AIData?.BotOwner == null || Enemy.EnemyPlayer.AIData.BotOwner.ProfileId == BotOwner.ProfileId)
+            // If the current enemy is AI, but no longer has a BotOwner or is ourselves, reset it
+            if (Enemy?.EnemyPlayer != null && Enemy.EnemyPlayer.IsAI == true && (Enemy?.EnemyPlayer.AIData?.BotOwner == null || Enemy.EnemyPlayer.AIData.BotOwner.ProfileId == BotOwner.ProfileId))
             {
                 Enemy = null;
             }
 
-            // For extra sanity, if the GoalEnemy's person's BotOwner is null, or ourselves, reset that too
-            if (BotOwner.Memory.GoalEnemy?.Person?.AIData?.BotOwner == null || BotOwner.Memory.GoalEnemy.Person.AIData.BotOwner.ProfileId == BotOwner.ProfileId)
+            // If our current enemy no longer exists, clean up
+            if (Enemy?.EnemyPlayer == null)
+            {
+                Enemy = null;
+            }
+
+            // For extra sanity, if the GoalEnemy is AI, and its BotOwner is null, or itself, reset that too
+            if (BotOwner.Memory.GoalEnemy?.Person?.IsAI == true && 
+                (BotOwner.Memory.GoalEnemy?.Person?.AIData?.BotOwner == null || BotOwner.Memory.GoalEnemy.Person.AIData.BotOwner.ProfileId == BotOwner.ProfileId))
             {
                 BotOwner.Memory.GoalEnemy = null;
             }

--- a/Components/Bot Components/SubComponents/Enemy/EnemyController.cs
+++ b/Components/Bot Components/SubComponents/Enemy/EnemyController.cs
@@ -31,13 +31,13 @@ namespace SAIN.Classes
             }
 
             // If our current enemy no longer exists, clean up
-            if (Enemy?.EnemyPlayer == null || Enemy?.EnemyPlayer.AIData?.BotOwner == null)
+            if (Enemy?.EnemyPlayer == null || Enemy?.EnemyPlayer.AIData?.BotOwner == null || Enemy.EnemyPlayer.AIData.BotOwner.ProfileId == BotOwner.ProfileId)
             {
                 Enemy = null;
             }
 
-            // For extra sanity, if the GoalEnemy's person's BotOwner is null, reset that too
-            if (BotOwner.Memory.GoalEnemy?.Person?.AIData?.BotOwner == null)
+            // For extra sanity, if the GoalEnemy's person's BotOwner is null, or ourselves, reset that too
+            if (BotOwner.Memory.GoalEnemy?.Person?.AIData?.BotOwner == null || BotOwner.Memory.GoalEnemy.Person.AIData.BotOwner.ProfileId == BotOwner.ProfileId)
             {
                 BotOwner.Memory.GoalEnemy = null;
             }
@@ -64,7 +64,7 @@ namespace SAIN.Classes
         public void AddEnemy(IAIDetails person)
         {
             string id = person.ProfileId;
-            
+
             // Check if the dictionary contains a previous SAINEnemy
             if (Enemies.ContainsKey(id))
             {
@@ -96,7 +96,8 @@ namespace SAIN.Classes
                 foreach (string id in Enemies.Keys)
                 {
                     var enemy = Enemies[id];
-                    if (enemy == null || enemy.EnemyPlayer == null || enemy.EnemyPlayer.AIData?.BotOwner == null || enemy.EnemyPlayer?.HealthController?.IsAlive == false)
+                    if (enemy == null || enemy.EnemyPlayer == null || enemy.EnemyPlayer.AIData?.BotOwner == null || enemy.EnemyPlayer.AIData.BotOwner.ProfileId == BotOwner.ProfileId ||
+                        enemy.EnemyPlayer?.HealthController?.IsAlive == false)
                     {
                         EnemyIDsToRemove.Add(id);
                     }

--- a/Components/Bot Components/SubComponents/Enemy/SAINEnemyClass.cs
+++ b/Components/Bot Components/SubComponents/Enemy/SAINEnemyClass.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.AI;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine.UIElements;
 
 namespace SAIN.Classes
 {
@@ -109,15 +110,24 @@ namespace SAIN.Classes
             if (DistanceTimer < Time.time)
             {
                 DistanceTimer = Time.time + 0.1f;
-                float distance = GetMagnitudeToBot(Position);
-                RealDistance = distance;
-                LastSeenDistance = IsVisible ? distance : GetMagnitudeToBot(PositionLastSeen);
-                DistanceFromLastSeen = IsVisible ? 0f : (PositionLastSeen - Position).magnitude;
+                if (Person != null)
+                {
+                    float distance = GetMagnitudeToBot(Position);
+                    RealDistance = distance;
+                    LastSeenDistance = IsVisible ? distance : GetMagnitudeToBot(PositionLastSeen);
+                    DistanceFromLastSeen = IsVisible ? 0f : (PositionLastSeen - Position).magnitude;
+                }
+                else
+                {
+                    RealDistance = 0;
+                    LastSeenDistance = 0;
+                    DistanceFromLastSeen = 0;
+                }
             }
         }
 
         public float DistanceFromLastSeen { get; private set; }
-        public Vector3 Position => Person.Position;
+        public Vector3 Position => (Person != null ? Person.Position : Vector3.zero);
 
         private float GetMagnitudeToBot(Vector3 point)
         {

--- a/Components/Bot Components/SubComponents/Mover/MoverClass.cs
+++ b/Components/Bot Components/SubComponents/Mover/MoverClass.cs
@@ -34,6 +34,7 @@ namespace SAIN.Classes
         private void Update()
         {
             if (BotOwner == null) return;
+            if (BotOwner.GetPlayer == null) return;
 
             SetStamina();
 
@@ -58,7 +59,7 @@ namespace SAIN.Classes
                 {
                     reachDist = BotOwner.Settings.FileSettings.Move.REACH_DIST;
                 }
-                BotOwner.Mover.GoToPoint(pointToGo, false, reachDist, false, false, false);
+                BotOwner.Mover?.GoToPoint(pointToGo, false, reachDist, false, false, false);
                 if (crawl)
                 {
                     Prone.SetProne(true);
@@ -77,7 +78,7 @@ namespace SAIN.Classes
                 {
                     reachDist = BotOwner.Settings.FileSettings.Move.REACH_DIST;
                 }
-                BotOwner.Mover.GoToByWay(Way, reachDist, BotOwner.Position);
+                BotOwner.Mover?.GoToByWay(Way, reachDist, BotOwner.Position);
                 if (crawl)
                 {
                     Prone.SetProne(true);
@@ -137,14 +138,14 @@ namespace SAIN.Classes
 
         public void SetTargetMoveSpeed(float speed)
         {
-            BotOwner.Mover.SetTargetMoveSpeed(speed);
+            BotOwner.Mover?.SetTargetMoveSpeed(speed);
         }
 
         public float DestMoveSpeed { get; private set; }
 
         public void StopMove()
         {
-            BotOwner.Mover.Stop();
+            BotOwner.Mover?.Stop();
             if (IsSprinting)
             {
                 Sprint(false);
@@ -154,7 +155,7 @@ namespace SAIN.Classes
         public void Sprint(bool value)
         {
             IsSprinting = value;
-            BotOwner.Mover.Sprint(value);
+            BotOwner.Mover?.Sprint(value);
             if (value)
             {
                 SAIN.Steering.LookToMovingDirection();

--- a/Components/Bot Components/SubComponents/Mover/PoseClass.cs
+++ b/Components/Bot Components/SubComponents/Mover/PoseClass.cs
@@ -59,14 +59,14 @@ namespace SAIN.Classes.Mover
 
         public void SetTargetPose(float num)
         {
-            BotOwner.Mover.SetPose(num);
+            BotOwner.Mover?.SetPose(num);
         }
 
         public bool SetTargetPose(float? num)
         {
             if (num != null)
             {
-                BotOwner.Mover.SetPose(num.Value);
+                BotOwner.Mover?.SetPose(num.Value);
             }
             return num != null;
         }


### PR DESCRIPTION
- Nullguard all accesses to BotOwner.Mover, one of these was throwing an exception on extract so I just nullguarded everything
- Refactor the logic for checking if a bot is an enemy into a method, for easier re-use between GoalEnemy and LastEnemy checks
- Refactor check in AddEnemy to make sure the player isn't constantly removed from the bot's enemy list
- Verify that `Person` is set in a few places, to make sure we don't access invalid target data