### PR TITLE
Fix squads not being created properly

### DIFF
--- a/BotController/Classes/BotSpawnController.cs
+++ b/BotController/Classes/BotSpawnController.cs
@@ -14,7 +14,10 @@ namespace SAIN.Components.BotController
 {
     public class BotSpawnController : SAINControl
     {
-        public BotSpawnController() { }
+        public static BotSpawnController Instance;
+        public BotSpawnController() {
+            Instance = this;
+        }
 
         public Dictionary<string, SAINComponentClass> SAINBotDictionary = new Dictionary<string, SAINComponentClass>();
         private BotSpawner BotSpawner => BotController?.BotSpawner;
@@ -32,7 +35,6 @@ namespace SAIN.Components.BotController
                 if (!Subscribed && !GameEnding)
                 {
                     BotSpawner.OnBotRemoved += RemoveBot;
-                    BotSpawner.OnBotCreated += AddBot;
                     Subscribed = true;
                 }
                 if (Subscribed)
@@ -41,7 +43,6 @@ namespace SAIN.Components.BotController
                     if (status == GameStatus.Stopping || status == GameStatus.Stopped || status == GameStatus.SoftStopping)
                     {
                         BotSpawner.OnBotRemoved -= RemoveBot;
-                        BotSpawner.OnBotCreated -= AddBot;
                         Subscribed = false;
                         GameEnding = true;
                     }

--- a/BotController/Classes/BotSquads.cs
+++ b/BotController/Classes/BotSquads.cs
@@ -332,7 +332,7 @@ namespace SAIN.BotController.Classes
             if (SAINPlugin.DebugMode)
             {
                 Logger.LogInfo(
-                    $" Found New Leader. Name [{sain.name}]" +
+                    $" Found New Leader. Name [{sain.BotOwner?.Profile?.Nickname}]" +
                     $" for Squad: [{Id}]" +
                     $" at Time: [{Time.time}]" +
                     $" Group Size: [{Members.Count}]"

--- a/Layers/Combat/Solo/CombatSoloLayer.cs
+++ b/Layers/Combat/Solo/CombatSoloLayer.cs
@@ -84,11 +84,14 @@ namespace SAIN.Layers.Combat.Solo
 
         public override bool IsActive()
         {
+            if (SAIN == null) return false;
+
             return CurrentDecision != SoloDecision.None;
         }
 
         public override bool IsCurrentActionEnding()
         {
+            if (SAIN == null) return true;
             return CurrentDecision != LastActionDecision;
         }
 

--- a/Layers/Combat/Squad/CombatSquadLayer.cs
+++ b/Layers/Combat/Squad/CombatSquadLayer.cs
@@ -36,11 +36,14 @@ namespace SAIN.Layers.Combat.Squad
 
         public override bool IsActive()
         {
+            if (SAIN == null) return false;
+
             return SAIN.Decision.CurrentSquadDecision != SquadDecision.None;
         }
 
         public override bool IsCurrentActionEnding()
         {
+            if (SAIN == null) return true;
             return SquadDecision != LastActionDecision;
         }
 

--- a/Layers/Extract/ExtractLayer.cs
+++ b/Layers/Extract/ExtractLayer.cs
@@ -17,6 +17,8 @@ namespace SAIN.Layers
 
         public override bool IsActive()
         {
+            if (SAIN == null) return false;
+
             if (SAIN.Memory.ExfilPosition == null || !SAIN.Info.FileSettings.Mind.EnableExtracts)
             {
                 return false;

--- a/Layers/SAINLayer.cs
+++ b/Layers/SAINLayer.cs
@@ -18,7 +18,6 @@ namespace SAIN.Layers
         public SAINLayer(BotOwner botOwner, int priority, string layerName) : base(botOwner, priority)
         {
             LayerName = layerName;
-            SAIN = botOwner.GetComponent<SAINComponentClass>();
         }
 
         private readonly string LayerName;
@@ -26,13 +25,29 @@ namespace SAIN.Layers
         public override string GetName() => LayerName;
 
         public SAINBotControllerComponent BotController => SAINPlugin.BotController;
-        public DecisionWrapper Decisions => SAIN.Memory.Decisions;
+        public DecisionWrapper Decisions => SAIN?.Memory?.Decisions;
 
-        public readonly SAINComponentClass SAIN;
+        private SAINComponentClass _SAIN = null;
+        public SAINComponentClass SAIN
+        {
+            get
+            {
+                if (_SAIN == null && BotOwner?.BotState == EBotState.Active)
+                {
+                    _SAIN = BotOwner.GetComponent<SAINComponentClass>();
+                }
+
+                return _SAIN;
+            }
+        }
+        
 
         public override void BuildDebugText(StringBuilder stringBuilder)
         {
-            DebugOverlay.AddBaseInfo(SAIN, BotOwner, stringBuilder);
+            if (SAIN != null)
+            {
+                DebugOverlay.AddBaseInfo(SAIN, BotOwner, stringBuilder);
+            }
         }
     }
 }

--- a/Plugin/Patches/AddComponentPatch.cs
+++ b/Plugin/Patches/AddComponentPatch.cs
@@ -3,6 +3,8 @@ using EFT;
 using HarmonyLib;
 using System.Reflection;
 using System;
+using SAIN.SAINComponent;
+using SAIN.Components.BotController;
 
 namespace SAIN.Patches.Components
 {
@@ -10,20 +12,15 @@ namespace SAIN.Patches.Components
     {
         protected override MethodBase GetTargetMethod()
         {
-            return AccessTools.Method(typeof(BotOwner), "PreActivate");
+            return AccessTools.Method(typeof(BotOwner), "method_10");
         }
 
         [PatchPostfix]
         public static void PatchPostfix(ref BotOwner __instance)
         {
-            if (__instance.IsRole(WildSpawnType.marksman))
-            {
-                return;
-            }
-
             try
             {
-                //SAINPlugin.SAINBotControllerComponent.AddBot(__instance);
+                BotSpawnController.Instance.AddBot(__instance);
             }
             catch (Exception ex)
             {

--- a/Plugin/SAINPlugin.cs
+++ b/Plugin/SAINPlugin.cs
@@ -318,7 +318,16 @@ namespace SAIN
             {
                 Logger.LogError(ex);
             }
-        }
+
+            try
+            {
+                new Patches.Components.AddComponentPatch().Enable();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex);
+            }
+}
 
         public static SAINPresetClass LoadedPreset => PresetHandler.LoadedPreset;
 

--- a/SAIN.csproj
+++ b/SAIN.csproj
@@ -461,6 +461,6 @@
     <PostBuildEvent>copy "$(TargetPath)" "$(ProjectDir)\..\..\BepInEx\plugins\$(TargetName)-$(ConfigurationName).dll"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File $(ProjectDir)\Plugin\VersionChecker\setbuild.ps1</PreBuildEvent>
+    <PreBuildEvent>powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "$(ProjectDir)\Plugin\VersionChecker\setbuild.ps1"</PreBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Attach the SAIN Component after bot activation so we have the correct BotsGroup info available
- Make sure brain layers only kick in once a SAIN component is available on the bot
- Re-enable usage of the AddComponentPatch, using the new BotSpawnController Instance
- Update the AddComponentPatch to apply after method_10, which is when the bot is Active
- Fix building with spaces in the build path