### PR TITLE
Fix CurPathLastPoint not being accurate any more

### DIFF
--- a/Helpers/HelpersGClass.cs
+++ b/Helpers/HelpersGClass.cs
@@ -42,6 +42,7 @@ namespace SAIN.Helpers
             InventoryControllerProp = AccessTools.Field(typeof(Player), "_inventoryController");
             EFTBotSettingsProp = AccessTools.Property(typeof(BotDifficultySettingsClass), "FileSettings");
             RefreshSettingsMethod = AccessTools.Method(typeof(BotDifficultySettingsClass), "method_0");
+            PathControllerField = AccessTools.Field(typeof(BotMover), "_pathController");
         }
 
         public static void RefreshSettings(BotDifficultySettingsClass settings)
@@ -53,6 +54,7 @@ namespace SAIN.Helpers
 
         public static readonly PropertyInfo EFTBotSettingsProp;
         public static readonly FieldInfo InventoryControllerProp;
+        public static readonly FieldInfo PathControllerField;
 
         public static InventoryControllerClass GetInventoryController(Player player)
         {
@@ -62,6 +64,11 @@ namespace SAIN.Helpers
         public static BotSettingsComponents GetEFTSettings(WildSpawnType type, BotDifficulty difficulty)
         {
             return (BotSettingsComponents)SAINPlugin.LoadedPreset.BotSettings.GetEFTSettings(type, difficulty);
+        }
+
+        public static PathControllerClass GetPathControllerClass(BotMover botMover)
+        {
+            return (PathControllerClass)PathControllerField.GetValue(botMover);
         }
 
         public static DateTime UtcNow => EFTTime.UtcNow;

--- a/Layers/Extract/ExtractAction.cs
+++ b/Layers/Extract/ExtractAction.cs
@@ -11,6 +11,7 @@ using EFT.Interactive;
 using System.Linq;
 using SAIN.Components.BotController;
 using UnityEngine.AI;
+using SAIN.Helpers;
 
 namespace SAIN.Layers
 {
@@ -132,7 +133,8 @@ namespace SAIN.Layers
                 ReCalcPathTimer = Time.time + 4f;
 
                 NavMeshPathStatus pathStatus = BotOwner.Mover.GoToPoint(point, true, 0.5f, false, false);
-                float distanceToEndOfPath = Vector3.Distance(BotOwner.Position, BotOwner.Mover.CurPathLastPoint);
+                var pathController = HelpersGClass.GetPathControllerClass(BotOwner.Mover);
+                float distanceToEndOfPath = Vector3.Distance(BotOwner.Position, pathController.CurPath.LastCorner());
                 bool reachedEndOfIncompletePath = (pathStatus == NavMeshPathStatus.PathPartial) && (distanceToEndOfPath < BotExtractManager.MinDistanceToExtract);
 
                 // If the path to the extract is invalid or the path is incomplete and the bot reached the end of it, select a new extract

--- a/SAINComponent/Classes/SAINCoverClass.cs
+++ b/SAINComponent/Classes/SAINCoverClass.cs
@@ -1,5 +1,6 @@
 ﻿using Comfort.Common;
 using EFT;
+using SAIN.Helpers;
 using SAIN.SAINComponent.SubComponents.CoverFinder;
 using System.Collections.Generic;
 using UnityEngine;
@@ -210,7 +211,8 @@ namespace SAIN.SAINComponent.Classes
                     return false;
                 }
                 var point = CoverInUse;
-                return point != null && (point.Position - BotOwner.Mover.CurPathLastPoint).sqrMagnitude < 1f;
+                var pathController = HelpersGClass.GetPathControllerClass(BotOwner.Mover);
+                return point != null && (point.Position - pathController.CurPath.LastCorner()).sqrMagnitude < 1f;
             }
         }
 


### PR DESCRIPTION
BSG changed the meaning of `CurPathLastPoint` in 0.14, so we need to use a different variable to get the end of the path