### PR TITLE
Fix doing unnecessary work if looting bots integration is disabled

### DIFF
--- a/Layers/Extract/ExtractLayer.cs
+++ b/Layers/Extract/ExtractLayer.cs
@@ -111,33 +111,25 @@ namespace SAIN.Layers
         // Looting Bots Integration
         private bool ExtractFromLoot()
         {
-            CheckForLootingBots();
-            SAINLootingBotsIntegration?.Update();
-            return FullOnLoot && HasActiveThreat() == false;
-        }
-
-        private void CheckForLootingBots()
-        {
-            if (LootingBots.LootingBotsInterop.Init())
+            // If extract from loot is disabled, or no Looting Bots interop, not active
+            if (SAINPlugin.LoadedPreset.GlobalSettings.LootingBots.ExtractFromLoot == false  || !LootingBots.LootingBotsInterop.Init())
             {
-                canUseLootingBotsInterop = true;
-            }
-            else
-            {
-                Logger.LogWarning("Looting Bots Interop not detected. Cannot instruct " + BotOwner.name + " to loot.");
+                return false;
             }
 
-            if (canUseLootingBotsInterop && SAINLootingBotsIntegration == null)
+            // No integration setup yet, set it up
+            if (SAINLootingBotsIntegration == null)
             {
                 SAINLootingBotsIntegration = new SAINLootingBotsIntegration(BotOwner, SAIN);
             }
+
+            SAINLootingBotsIntegration?.Update();
+            return FullOnLoot && HasActiveThreat() == false;
         }
 
         private bool FullOnLoot => SAINLootingBotsIntegration?.FullOnLoot == true;
 
         private SAINLootingBotsIntegration SAINLootingBotsIntegration;
-
-        private bool canUseLootingBotsInterop = false;
 
         private bool HasActiveThreat()
         {

--- a/Layers/Extract/SAINLootingBotsIntegration.cs
+++ b/Layers/Extract/SAINLootingBotsIntegration.cs
@@ -28,11 +28,6 @@ namespace SAIN.Layers
 
         private void CheckStatus()
         {
-            if (SAINPlugin.LoadedPreset.GlobalSettings.LootingBots.ExtractFromLoot == false)
-            {
-                FullOnLoot = false;
-                return;
-            }
             if (!FullOnLoot && CanExtractFromLootValue())
             {
                 Logger.LogInfo($"[{BotOwner.name}] Is Moving to Extract because because they are Full on loot. Net Loot Value: {NetLootValue}");


### PR DESCRIPTION
- Check the ExtractFromLoot setting in ExtractLayer so we do the least amount of work necessary if it's disables
- Check LootingBotsInterop in ExtractFromLoot so we do the leas amount of work necessary if it's not found
- Remove log message when looting bots isn't installed