### PR TITLE
Previously discussed changes to SAIN vision modifiers (Movement/Elevation)

### DIFF
--- a/Plugin/Patches/VisionPatches.cs
+++ b/Plugin/Patches/VisionPatches.cs
@@ -251,20 +251,26 @@ namespace SAIN.Patches.Vision
                         __result *= inverseWeatherModifier;
                     }
 
+                    Preset.GlobalSettings.LookSettings globalLookSettings = SAINPlugin.LoadedPreset.GlobalSettings.Look;
                     if (player.IsSprintEnabled)
                     {
-                        __result *= 0.66f;
+                        __result *= Mathf.Lerp(1, globalLookSettings.SprintingVisionModifier, Mathf.InverseLerp(0, 5f, player.Velocity.magnitude)); // 5f is the observed max sprinting speed with gameplays (with Realism, which gives faster sprinting)
                     }
 
-                    float elevationDifference = enemy.position.y - BotTransform.position.y;
-                    if (elevationDifference > 2f)
+                    Vector3 botEyeToPlayerBody = __instance.Person.MainParts[BodyPartType.body].Position - __instance.Owner.MainParts[BodyPartType.head].Position;
+                    var visionAngleDeviation = Vector3.Angle(new Vector3(botEyeToPlayerBody.x, 0f, botEyeToPlayerBody.z), botEyeToPlayerBody);
+
+                    if (botEyeToPlayerBody.y >= 0)
                     {
-                        __result *= 1.33f;
+                        float angleFactor = Mathf.InverseLerp(0, globalLookSettings.HighElevationMaxAngle, visionAngleDeviation);
+                        __result *= Mathf.Lerp(1f, globalLookSettings.HighElevationVisionModifier, angleFactor);
                     }
-                    if (elevationDifference < -2f)
+                    else
                     {
-                        __result *= 0.85f;
+                        float angleFactor = Mathf.InverseLerp(0, globalLookSettings.LowElevationMaxAngle, visionAngleDeviation);
+                        __result *= Mathf.Lerp(1f, globalLookSettings.LowElevationVisionModifier, angleFactor);
                     }
+        
                     if (!player.IsAI)
                     {
                         __result *= SAINNotLooking.GetVisionSpeedIncrease(__instance.Owner);

--- a/Preset/GlobalSettings/Categories/LookSettings.cs
+++ b/Preset/GlobalSettings/Categories/LookSettings.cs
@@ -22,6 +22,46 @@ namespace SAIN.Preset.GlobalSettings
         [MinMax(0.01f, 5f, 100f)]
         public float GlobalVisionSpeedModifier = 1;
 
+        [Name("Sprinting Vision Modifier")]
+        [Description(
+            "Bots will see sprinting players this much faster, at any range." +
+            "Higher is slower speed, so 0.66 would result in bots taking 0.66 times longer to spot an sprinting enemy")]
+        [Default(0.66f)]
+        [MinMax(0.01f, 1f, 100f)]
+        public float SprintingVisionModifier = 0.66f;
+
+        [Name("High Elevation Angle Range")]
+        [Description(
+            "The difference of angle from the bot's vision to the enemy to fully apply HighElevationVisionModifier. " +
+            "The modifier is smoothed out by the angle differnce. So 1.2x at +60 degree, 1.1x at +30 degrees...and so on.")]
+        [Default(60f)]
+        [MinMax(1f, 90f, 1f)]
+        public float HighElevationMaxAngle = 60f;
+
+        [Name("High Elevation Vision Modifier")]
+        [Description(
+            "Bots will see sprinting players this much slower when the enemy's altitude is higher than the bot when the vision angle difference is equal or greater than HighElevationMaxAngle. " +
+            "Higher is slower speed, so 1.2 would result in bots taking 20% longer to spot an enemy")]
+        [Default(1.2f)]
+        [MinMax(1f, 5f, 100f)]
+        public float HighElevationVisionModifier = 1.2f;
+
+        [Name("Low Elevation Angle Range")]
+        [Description(
+            "The difference of angle from the bot's vision to the enemy to fully apply LowElevationVisionModifier. " +
+            "The modifier is smoothed out by the angle differnce. So 0.85x at -30 degree, 0.95x at -10 degrees...and so on.")]
+        [Default(30f)]
+        [MinMax(1f, 90f, 1f)]
+        public float LowElevationMaxAngle = 30f;
+
+        [Name("Low Elevation Vision Modifier")]
+        [Description(
+            "Bots will see sprinting players this much slower when the enemy's altitude is lower than the bot when the vision angle difference is equal or greater than LowElevationMaxAngle. " +
+            "Higher is slower speed, so 0.85 would result in bots taking 15% shorter to spot an enemy")]
+        [Default(0.85f)]
+        [MinMax(0.01f, 1f, 100f)]
+        public float LowElevationVisionModifier = 0.85f;
+
         [Name("Nighttime Vision Modifier")]
         [Description(
             "By how much to lower visible distance at nighttime. " +

--- a/SAINComponent/Classes/Sense/SAINVisionClass.cs
+++ b/SAINComponent/Classes/Sense/SAINVisionClass.cs
@@ -36,10 +36,11 @@ namespace SAIN.SAINComponent.Classes
                 return result;
             }
             var pose = player.Pose;
-            float speed = player.Velocity.magnitude / player.MovementContext.MaxSpeed;
+            float speed = player.Velocity.magnitude / 5f; // 5f is the observed max sprinting speed with gameplays (with Realism, which gives faster sprinting)
             if (player.MovementContext.IsSprintEnabled)
             {
-                result *= 1.33f;
+                Preset.GlobalSettings.LookSettings globalLookSettings = SAINPlugin.LoadedPreset.GlobalSettings.Look;
+                result *= Mathf.Lerp(1, globalLookSettings.SprintingVisionModifier, Mathf.InverseLerp(0, 5f, player.Velocity.magnitude));
             }
             else switch (pose)
             {


### PR DESCRIPTION
As previously discussed in DC on 5/11, adding global look configs for bot vision modifier from player movement and elevation, so players get to configure or toggle these kind of features between SAIN and That's Lit.

Instead of applying modifiers by sprinting or not, the modifier are smoothed out by player speed in a range of 0 to 5, as 5 is the actual observed max speed with Realism, which gives player higher sprinting speed.

In a separate commit, similar change is applied to vision distance modifier in SAINVision.cs, as the MovementContext.MaxSpeed does not seems to work as we could imagine. (It's 0.615 regardless any control and movement in my short test on Day Factory)

Vision modifier from elevation is smoothed out by vertical vision angle, too. This way, players on higher floors from afar are not equally buffed as players above of the bot.