### PR TITLE
Adjustments and fixes for SPT 3.11

### DIFF
--- a/Components/BotComponentSpace/BotComponent.cs
+++ b/Components/BotComponentSpace/BotComponent.cs
@@ -80,8 +80,8 @@ namespace SAIN.SAINComponent
         public float DistanceToAimTarget {
             get
             {
-                if (BotOwner.AimingData != null) {
-                    return BotOwner.AimingData.LastDist2Target;
+                if (BotOwner.AimingManager.CurrentAiming != null) {
+                    return BotOwner.AimingManager.CurrentAiming.LastDist2Target;
                 }
                 return CurrentTarget.CurrentTargetDistance;
             }
@@ -298,7 +298,7 @@ namespace SAIN.SAINComponent
 
                 try {
 					BotOwner.LookSensor.MaxShootDist = float.MaxValue;
-					if (BotOwner.AIData is GClass551 aiData)
+					if (BotOwner.AIData is GClass567 aiData)
 					{
 						aiData.IsNoOffsetShooting = false;
 					}

--- a/Components/BotComponentSpace/Classes/BotBusyHandsDetector.cs
+++ b/Components/BotComponentSpace/Classes/BotBusyHandsDetector.cs
@@ -216,7 +216,7 @@ namespace SAIN.SAINComponent.Classes
 
             try
             {
-                player.SpawnController(player.method_127());
+                player.SpawnController(player.HandsController);
             }
             catch (Exception ex)
             {
@@ -233,7 +233,7 @@ namespace SAIN.SAINComponent.Classes
             else
             {
                 player.ProcessStatus = EProcessStatus.None;
-                player.SetFirstAvailableItem(PlayerOwner.Class1643.class1643_0.method_0);
+                player.SetFirstAvailableItem(PlayerOwner.Class1667.class1667_0.method_0);
             }
 
             player.SetInventoryOpened(false);

--- a/Components/BotComponentSpace/Classes/BotWeightManagement.cs
+++ b/Components/BotComponentSpace/Classes/BotWeightManagement.cs
@@ -3,7 +3,7 @@ using HarmonyLib;
 using SAIN.Preset.GlobalSettings;
 using System;
 using System.Collections.Generic;
-using FloatFunc = GClass817<float>;
+using FloatFunc = GClass828<float>;
 
 namespace SAIN.SAINComponent.Classes
 {

--- a/Components/BotComponentSpace/Classes/Doors/DoorOpener.cs
+++ b/Components/BotComponentSpace/Classes/Doors/DoorOpener.cs
@@ -270,7 +270,7 @@ namespace SAIN.SAINComponent.Classes.Mover
             _possibleInteractDoors.Clear();
 
             Vector3 targetMovePos;
-            if (BotOwner.Mover.HavePath)
+            if (BotOwner.Mover._pathController.HavePath)
                 targetMovePos = BotOwner.Mover.RealDestPoint;
             else if (Bot.Mover.SprintController.Running)
                 targetMovePos = Bot.Mover.SprintController.CurrentCornerDestination();
@@ -567,7 +567,7 @@ namespace SAIN.SAINComponent.Classes.Mover
         private bool checkCrossPoint(Vector3 goTo, Vector3 botPosition, DoorData data)
         {
             NavMeshDoorLink link = data.Link;
-			GClass340 gclass;
+			GClass355 gclass;
             switch (link.Door.DoorState)
             {
                 case EDoorState.Open:

--- a/Components/BotComponentSpace/Classes/Mover/SAINMoverClass.cs
+++ b/Components/BotComponentSpace/Classes/Mover/SAINMoverClass.cs
@@ -116,7 +116,7 @@ namespace SAIN.SAINComponent.Classes.Mover
             }
             // Is the bot currently Moving somewhere?
             if (SprintController.Running ||
-                BotOwner.Mover?.HavePath == true) {
+                BotOwner.Mover?._pathController.HavePath == true) {
                 return;
             }
             // Did the bot jump recently?
@@ -148,7 +148,7 @@ namespace SAIN.SAINComponent.Classes.Mover
             Vector3 position = Bot.Position;
             if ((_prevLinkPos - position).sqrMagnitude > 0f) {
                 Vector3 castPoint = position + Vector3.up * 0.3f;
-                BotOwner.Mover.SetPlayerToNavMesh(position, castPoint);
+                BotOwner.Mover.SetPlayerToNavMesh(castPoint);
                 _prevLinkPos = position;
             }
         }
@@ -174,7 +174,7 @@ namespace SAIN.SAINComponent.Classes.Mover
 
         public Vector3 CurrentMoveDestination { get; private set; }
 
-        public bool Moving => BotOwner.Mover?.IsMoving == true || BotOwner.Mover?.HavePath == true;
+        public bool Moving => BotOwner.Mover?.IsMoving == true || BotOwner.Mover?._pathController.HavePath == true;
 
         public bool GoToPoint(Vector3 point, out bool calculating, float reachDist = -1f, bool crawl = false, bool slowAtEnd = true, bool mustHaveCompletePath = true)
         {

--- a/Components/BotComponentSpace/Classes/Mover/SAINSprint.cs
+++ b/Components/BotComponentSpace/Classes/Mover/SAINSprint.cs
@@ -141,7 +141,7 @@ namespace SAIN.SAINComponent.Classes.Mover
         private void startRun(NavMeshPath path, Vector3 point, ESprintUrgency urgency, System.Action callback)
         {
             stopRunCoroutine();
-            BotOwner.AimingData?.LoseTarget();
+            BotOwner.AimingManager.CurrentAiming?.LoseTarget();
             LastRunDestination = point;
             CurrentPath = path;
             _lastUrgency = urgency;
@@ -561,7 +561,7 @@ namespace SAIN.SAINComponent.Classes.Mover
                 direction *= 10f;
             }
             Player.CharacterController.SetSteerDirection(direction);
-            BotOwner.AimingData?.Move(Player.Speed);
+            BotOwner.AimingManager.CurrentAiming?.Move(Player.Speed);
 			if (BotOwner.Mover != null)
 			{
 				BotOwner.Mover.IsMoving = true;

--- a/Components/BotComponentSpace/Classes/SAINBotUnstuckClass.cs
+++ b/Components/BotComponentSpace/Classes/SAINBotUnstuckClass.cs
@@ -445,7 +445,7 @@ namespace SAIN.SAINComponent.Classes.Debug
             Vector3? teleportDestination = null;
 
             const float minTeleDist = 1f;
-            if (BotOwner.Mover.HavePath)
+            if (BotOwner.Mover._pathController.HavePath)
             {
                 for (int i = PathController.CurPath.CurIndex; i < PathController.CurPath.Length - 1; i++)
                 {

--- a/Components/BotComponentSpace/Classes/Sense/SAINBotLookClass.cs
+++ b/Components/BotComponentSpace/Classes/Sense/SAINBotLookClass.cs
@@ -7,8 +7,8 @@ using UnityEngine;
 
 // Found in Botowner.Looksensor
 using EnemyTotalCheck = GClass568;
-using EnemyVisionCheck = GClass548;
-using LookAllData = GClass573;
+using EnemyVisionCheck = GClass564;
+using LookAllData = GClass589;
 
 namespace SAIN.SAINComponent.Classes
 {
@@ -52,15 +52,15 @@ namespace SAIN.SAINComponent.Classes
 
         public void UpdateLookData(LookAllData lookData)
         {
-            for (int i = 0; i < lookData.reportsData.Count; i++) {
-                EnemyVisionCheck enemyVision = lookData.reportsData[i];
-                BotOwner.BotsGroup.ReportAboutEnemy(enemyVision.enemy, enemyVision.VisibleOnlyBuSence);
+            for (int i = 0; i < lookData.ReportsData.Count; i++) {
+                EnemyVisionCheck enemyVision = lookData.ReportsData[i];
+                BotOwner.BotsGroup.ReportAboutEnemy(enemyVision.Enemy, enemyVision.VisibleOnlyBySence);
             }
 
-            if (lookData.reportsData.Count > 0)
+            if (lookData.ReportsData.Count > 0)
                 BotOwner.Memory.SetLastTimeSeeEnemy();
 
-            if (lookData.shallRecalcGoal)
+            if (lookData.ShallRecalcGoal)
                 BotOwner.CalcGoal();
 
             lookData.Reset();
@@ -101,8 +101,8 @@ namespace SAIN.SAINComponent.Classes
         private void setNotVis(Enemy enemy)
         {
             foreach (var part in enemy.EnemyInfo.AllActiveParts.Values) {
-                if (part.IsVisible || part.VisibleBySense) {
-                    part.UpdateVision(1000f, false, false, false, BotOwner);
+                if (part.IsVisible || part.VisibleType == EEnemyPartVisibleType.Sence) {
+                    part.UpdateVisibility(BotOwner, false, false, false, Time.deltaTime, 1f);
                 }
             }
             if (enemy.EnemyInfo.IsVisible) {
@@ -117,7 +117,7 @@ namespace SAIN.SAINComponent.Classes
             float timeSince = Time.time - look.LastCheckLookTime;
             if (timeSince >= delay) {
                 look.LastCheckLookTime = Time.time;
-                enemy.EnemyInfo.CheckLookEnemy(lookAll);
+                enemy.EnemyInfo.CheckLookEnemy(lookAll, Time.deltaTime);
                 return true;
             }
             return false;

--- a/Components/BotComponentSpace/Classes/Sense/SAINFriendlyFireClass.cs
+++ b/Components/BotComponentSpace/Classes/Sense/SAINFriendlyFireClass.cs
@@ -50,7 +50,7 @@ namespace SAIN.SAINComponent.Classes
                 return checkFriendlyFire(target.Value);
             }
 
-            var aimData = BotOwner?.AimingData;
+            var aimData = BotOwner?.AimingManager.CurrentAiming;
             if (aimData == null)
             {
                 return FriendlyFireStatus.None;

--- a/Components/BotComponentSpace/Classes/Steering/SteerPriorityClass.cs
+++ b/Components/BotComponentSpace/Classes/Steering/SteerPriorityClass.cs
@@ -30,7 +30,7 @@ namespace SAIN.SAINComponent.Classes.Mover
         public AimStatus AimStatus {
             get
             {
-                object aimStatus = aimStatusField.GetValue(BotOwner.AimingData);
+                object aimStatus = aimStatusField.GetValue(BotOwner.AimingManager.CurrentAiming);
                 if (aimStatus == null) {
                     return AimStatus.NoTarget;
                 }

--- a/Components/BotComponentSpace/Classes/Talk/SAINBotTalkClass.cs
+++ b/Components/BotComponentSpace/Classes/Talk/SAINBotTalkClass.cs
@@ -373,7 +373,7 @@ namespace SAIN.SAINComponent.Classes.Talk
             AddPhrase(EPhraseTrigger.Roger, 10, 30f, dictionary);
             AddPhrase(EPhraseTrigger.Negative, 10, 30f, dictionary);
             AddPhrase(EPhraseTrigger.PhraseNone, 1, 1f, dictionary);
-            AddPhrase(EPhraseTrigger.Attention, 25, 30f, dictionary);
+            AddPhrase(EPhraseTrigger.Look, 25, 30f, dictionary);
             AddPhrase(EPhraseTrigger.OnYourOwn, 25, 15f, dictionary);
             AddPhrase(EPhraseTrigger.Repeat, 25, 30f, dictionary);
             AddPhrase(EPhraseTrigger.CoverMe, 25, 45f, dictionary);

--- a/Components/BotComponentSpace/Classes/WeaponFunction/AimClass.cs
+++ b/Components/BotComponentSpace/Classes/WeaponFunction/AimClass.cs
@@ -197,7 +197,7 @@ namespace SAIN.SAINComponent.Classes.WeaponFunction
         public AimStatus AimStatus {
             get
             {
-                object aimStatus = aimStatusField.GetValue(BotOwner.AimingData);
+                object aimStatus = aimStatusField.GetValue(BotOwner.AimingManager.CurrentAiming);
                 if (aimStatus == null) {
                     return AimStatus.NoTarget;
                 }
@@ -243,7 +243,7 @@ namespace SAIN.SAINComponent.Classes.WeaponFunction
 
         private bool canAim()
         {
-            var aimData = BotOwner.AimingData;
+            var aimData = BotOwner.AimingManager.CurrentAiming;
             if (aimData == null) {
                 //return false;
             }
@@ -262,7 +262,7 @@ namespace SAIN.SAINComponent.Classes.WeaponFunction
         private void checkLoseTarget()
         {
             if (!CanAim) {
-                BotOwner.AimingData?.LoseTarget();
+                BotOwner.AimingManager.CurrentAiming?.LoseTarget();
                 return;
             }
         }

--- a/Components/BotComponentSpace/Classes/WeaponFunction/AimDownSightsController.cs
+++ b/Components/BotComponentSpace/Classes/WeaponFunction/AimDownSightsController.cs
@@ -98,7 +98,7 @@ namespace SAIN.SAINComponent.Classes.WeaponFunction
             get
             {
                 if (_botAimingClass == null) {
-                    var aimData = BotOwner.AimingData;
+                    var aimData = BotOwner.AimingManager.CurrentAiming;
                     if (aimData != null && aimData is BotAimingClass aimClass) {
                         _botAimingClass = aimClass;
                     }

--- a/Components/BotComponentSpace/Classes/WeaponFunction/Firerate.cs
+++ b/Components/BotComponentSpace/Classes/WeaponFunction/Firerate.cs
@@ -40,7 +40,7 @@ namespace SAIN.SAINComponent.Classes.WeaponFunction
 
             float minTime = 0.1f; // minimum time per shot
             float maxTime = 4f; // maximum time per shot
-            float EnemyDistance = (BotOwner.AimingData.RealTargetPoint - BotOwner.WeaponRoot.position).magnitude;
+            float EnemyDistance = (BotOwner.AimingManager.CurrentAiming.RealTargetPoint - BotOwner.WeaponRoot.position).magnitude;
 
             float rate = EnemyDistance / (PerMeter / weaponInfo.FinalModifier);
             float final = Mathf.Clamp(rate, minTime, maxTime);

--- a/Components/BotComponentSpace/Classes/WeaponFunction/Grenades/GrenadeThrowDecider.cs
+++ b/Components/BotComponentSpace/Classes/WeaponFunction/Grenades/GrenadeThrowDecider.cs
@@ -2,7 +2,7 @@
 using SAIN.Preset;
 using SAIN.SAINComponent.Classes.EnemyClasses;
 using UnityEngine;
-using GrenadeThrowChecker = GClass541;
+using GrenadeThrowChecker = GClass557;
 
 namespace SAIN.SAINComponent.Classes.WeaponFunction
 {

--- a/Components/BotComponentSpace/Classes/WeaponFunction/Recoil.cs
+++ b/Components/BotComponentSpace/Classes/WeaponFunction/Recoil.cs
@@ -92,7 +92,7 @@ namespace SAIN.SAINComponent.Classes.WeaponFunction
             CurrentRecoilOffset += result;
 
             if (SAINPlugin.DebugSettings.Gizmos.DebugDrawRecoilGizmos) {
-                DebugGizmos.Ray(Bot.Transform.WeaponFirePort, dir * BotOwner.AimingData.LastDist2Target, Color.red, BotOwner.AimingData.LastDist2Target, 0.02f, true, 10f);
+                DebugGizmos.Ray(Bot.Transform.WeaponFirePort, dir * BotOwner.AimingManager.CurrentAiming.LastDist2Target, Color.red, BotOwner.AimingManager.CurrentAiming.LastDist2Target, 0.02f, true, 10f);
             }
 
             if (_debugRecoilLogs)

--- a/Components/BotComponentSpace/Classes/WeaponFunction/ShootDeciderClass.cs
+++ b/Components/BotComponentSpace/Classes/WeaponFunction/ShootDeciderClass.cs
@@ -100,7 +100,7 @@ namespace SAIN.SAINComponent.Classes
                     Bot.Mover.PauseMovement(Random.Range(_pauseMoveDurationMin, _pauseMoveDurationMax));
                 }
                 if (!IsMovementPaused) {
-                    BotOwner.AimingData?.LoseTarget();
+                    BotOwner.AimingManager.CurrentAiming?.LoseTarget();
                     return false;
                 }
             }
@@ -122,7 +122,7 @@ namespace SAIN.SAINComponent.Classes
         public bool IsAiming {
             get
             {
-                return BotOwner?.ShootData?.ShootController?.IsAiming == true || BotOwner?.AimingData?.IsReady == true;
+                return BotOwner?.ShootData?.ShootController?.IsAiming == true || BotOwner?.AimingManager.CurrentAiming?.IsReady == true;
             }
         }
 
@@ -228,7 +228,7 @@ namespace SAIN.SAINComponent.Classes
 
         private bool aimAtTarget(Vector3 target)
         {
-            var aimData = BotOwner.AimingData;
+            var aimData = BotOwner.AimingManager.CurrentAiming;
             //AimStatus aimStatus = Bot.Aim.AimStatus;
             //bool steerComplete = false;
 

--- a/Components/BotComponentSpace/SubComponents/GrenadeTrackerComponent.cs
+++ b/Components/BotComponentSpace/SubComponents/GrenadeTrackerComponent.cs
@@ -48,7 +48,7 @@ namespace SAIN.SAINComponent.SubComponents
                 _sentToBot = true;
                 var collisionSound = Grenade.GrenadeSettings.CollisionSound;
                 bool isFrag = collisionSound == GrenadeSettings.CollisionSounds.frag;
-                var trigger = isFrag ? EPhraseTrigger.OnEnemyGrenade : EPhraseTrigger.Attention;
+                var trigger = isFrag ? EPhraseTrigger.OnEnemyGrenade : EPhraseTrigger.Look;
                 Bot.Talk.GroupSay(trigger, ETagStatus.Combat, false, 70);
 
                 Vector3 pos = DangerPoint;

--- a/Components/GameWorldSpace/Info/LocationClass.cs
+++ b/Components/GameWorldSpace/Info/LocationClass.cs
@@ -1,5 +1,5 @@
 ﻿using UnityEngine;
-using SeasonController = Class442;
+using SeasonController = Class436;
 
 namespace SAIN.Components
 {

--- a/Components/SAINNoBushESP.cs
+++ b/Components/SAINNoBushESP.cs
@@ -177,7 +177,7 @@ namespace SAIN.Components
                     enemy.SetCanShoot(false);
                     enemy.SetVisible(false);
 
-                    BotOwner.AimingData?.LoseTarget();
+                    BotOwner.AimingManager.CurrentAiming?.LoseTarget();
 
                     var vision = SAIN?.EnemyController.GetEnemy(enemy.ProfileId, false)?.Vision;
                     if (vision != null)

--- a/Helpers/HelpersGClass.cs
+++ b/Helpers/HelpersGClass.cs
@@ -6,8 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using EFTCore = GClass583;
-using EFTStatModifiersClass = GClass580;
+using EFTCore = GClass598;
+using EFTStatModifiersClass = GClass595;
 
 ////////
 // Fixed some GClass References here, but classes were renamed in the deobfuscation, so much of this isn't necessary anymore. Need to clean this up

--- a/Helpers/HelpersGClass.cs
+++ b/Helpers/HelpersGClass.cs
@@ -23,7 +23,7 @@ namespace SAIN.Helpers
             EFTBotSettingsProp = AccessTools.Property(typeof(BotDifficultySettingsClass), "FileSettings");
             RefreshSettingsMethod = AccessTools.Method(typeof(BotDifficultySettingsClass), "method_0");
             PathControllerField = AccessTools.Field(typeof(BotMover), "_pathController");
-            AimDataType = PatchConstants.EftTypes.Single(x => x.GetProperty("LastSpreadCount") != null && x.GetProperty("LastAimTime") != null);
+            AimDataType = typeof(BotAimingClass);
         }
 
         public static readonly Type AimDataType;

--- a/Layers/Combat/Solo/Cover/DoSurgeryAction.cs
+++ b/Layers/Combat/Solo/Cover/DoSurgeryAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using System.Collections;
 using System.Text;
 using UnityEngine;
@@ -16,7 +17,7 @@ namespace SAIN.Layers.Combat.Solo.Cover
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             if (Bot.Medical.Surgery.AreaClearForSurgery) {
                 Bot.Mover.PauseMovement(30);

--- a/Layers/Combat/Solo/Cover/HoldinCoverAction.cs
+++ b/Layers/Combat/Solo/Cover/HoldinCoverAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.Helpers;
 using SAIN.SAINComponent.Classes.EnemyClasses;
 using SAIN.SAINComponent.SubComponents.CoverFinder;
@@ -18,7 +19,7 @@ namespace SAIN.Layers.Combat.Solo.Cover
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Bot.Steering.SteerByPriority();
             Shoot.CheckAimAndFire();

--- a/Layers/Combat/Solo/Cover/RunToCoverAction.cs
+++ b/Layers/Combat/Solo/Cover/RunToCoverAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.Helpers;
 using SAIN.SAINComponent.Classes.Mover;
 using SAIN.SAINComponent.SubComponents.CoverFinder;
@@ -21,7 +22,7 @@ namespace SAIN.Layers.Combat.Solo.Cover
 
         private bool _runFailed;
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Bot.Mover.SetTargetMoveSpeed(1f);
             Bot.Mover.SetTargetPose(1f);

--- a/Layers/Combat/Solo/Cover/ShiftCoverAction.cs
+++ b/Layers/Combat/Solo/Cover/ShiftCoverAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.Helpers;
 using SAIN.SAINComponent.SubComponents.CoverFinder;
 using System.Collections;
@@ -19,7 +20,7 @@ namespace SAIN.Layers.Combat.Solo.Cover
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Bot.Steering.SteerByPriority();
             Shoot.CheckAimAndFire();

--- a/Layers/Combat/Solo/Cover/WalkToCoverAction.cs
+++ b/Layers/Combat/Solo/Cover/WalkToCoverAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.SAINComponent.Classes.WeaponFunction;
 using SAIN.SAINComponent.SubComponents.CoverFinder;
 using System.Text;
@@ -19,7 +20,7 @@ namespace SAIN.Layers.Combat.Solo.Cover
 
         private float _nextUpdateCoverTime;
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Bot.Mover.SetTargetMoveSpeed(1f);
             Bot.Mover.SetTargetPose(1f);

--- a/Layers/Combat/Solo/DogFightAction.cs
+++ b/Layers/Combat/Solo/DogFightAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using System.Collections;
 using UnityEngine;
 
@@ -10,7 +11,7 @@ namespace SAIN.Layers.Combat.Solo
         {
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Bot.Mover.SetTargetPose(1f);
             Bot.Mover.SetTargetMoveSpeed(1f);

--- a/Layers/Combat/Solo/FlankAction.cs
+++ b/Layers/Combat/Solo/FlankAction.cs
@@ -28,7 +28,7 @@ namespace SAIN.Layers.Combat.Solo
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Enemy enemy = Bot.Enemy;
             if (enemy != null)

--- a/Layers/Combat/Solo/FreezeAction.cs
+++ b/Layers/Combat/Solo/FreezeAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using System.Collections;
 
 namespace SAIN.Layers.Combat.Solo
@@ -14,7 +15,7 @@ namespace SAIN.Layers.Combat.Solo
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Bot.Mover.SetTargetPose(0f);
             if (!Bot.Steering.SteerByPriority(null, false)) {

--- a/Layers/Combat/Solo/MeleeAttackAction.cs
+++ b/Layers/Combat/Solo/MeleeAttackAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using System.Collections;
 
 namespace SAIN.Layers.Combat.Solo
@@ -9,7 +10,7 @@ namespace SAIN.Layers.Combat.Solo
         {
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             BotOwner.WeaponManager.Melee.RunToEnemyUpdate();
         }

--- a/Layers/Combat/Solo/MoveToEngageAction.cs
+++ b/Layers/Combat/Solo/MoveToEngageAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.SAINComponent.Classes.EnemyClasses;
 using System.Collections;
 using UnityEngine;
@@ -18,7 +19,7 @@ namespace SAIN.Layers.Combat.Solo
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Enemy enemy = Bot.Enemy;
             if (enemy == null) {

--- a/Layers/Combat/Solo/RushEnemyAction.cs
+++ b/Layers/Combat/Solo/RushEnemyAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.Helpers;
 using SAIN.SAINComponent.Classes.EnemyClasses;
 using System.Collections;
@@ -13,7 +14,7 @@ namespace SAIN.Layers.Combat.Solo
         {
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Bot.Mover.SetTargetPose(1f);
             Bot.Mover.SetTargetMoveSpeed(1f);

--- a/Layers/Combat/Solo/SearchAction.cs
+++ b/Layers/Combat/Solo/SearchAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.Helpers;
 using SAIN.SAINComponent.Classes.EnemyClasses;
 using SAIN.SAINComponent.Classes.Search;
@@ -38,7 +39,7 @@ namespace SAIN.Layers.Combat.Solo
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             setTargetEnemy();
             var enemy = _searchTarget;

--- a/Layers/Combat/Solo/ShootAction.cs
+++ b/Layers/Combat/Solo/ShootAction.cs
@@ -29,7 +29,7 @@ namespace SAIN.Layers.Combat.Solo
             Toggle(false);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Bot.Steering.SteerByPriority();
             Shoot.CheckAimAndFire();

--- a/Layers/Combat/Solo/StandAndShootAction.cs
+++ b/Layers/Combat/Solo/StandAndShootAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.Helpers;
 using System.Collections;
 using UnityEngine;
@@ -17,7 +18,7 @@ namespace SAIN.Layers.Combat.Solo
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Bot.Steering.SteerByPriority();
             if (!shallMoveShoot)

--- a/Layers/Combat/Solo/ThrowGrenadeAction.cs
+++ b/Layers/Combat/Solo/ThrowGrenadeAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using System.Collections;
 using UnityEngine;
 
@@ -15,7 +16,7 @@ namespace SAIN.Layers.Combat.Solo
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             if (!Stopped && Time.time - StartTime > 1f || Bot.Cover.CheckLimbsForCover()) {
                 Stopped = true;

--- a/Layers/Combat/Squad/AssaultAction.cs
+++ b/Layers/Combat/Squad/AssaultAction.cs
@@ -14,7 +14,7 @@ namespace SAIN.Layers.Combat.Squad
         {
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Shoot.CheckAimAndFire();
 

--- a/Layers/Combat/Squad/FollowSearchParty - Copy.cs
+++ b/Layers/Combat/Squad/FollowSearchParty - Copy.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.SAINComponent.Classes.EnemyClasses;
 using System.Collections;
 using UnityEngine;
@@ -17,7 +18,7 @@ namespace SAIN.Layers.Combat.Squad
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
         }
 
@@ -45,7 +46,7 @@ namespace SAIN.Layers.Combat.Squad
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
         }
 

--- a/Layers/Combat/Squad/FollowSearchParty.cs
+++ b/Layers/Combat/Squad/FollowSearchParty.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.SAINComponent.Classes.EnemyClasses;
 using System.Collections;
 using UnityEngine;
@@ -18,7 +19,7 @@ namespace SAIN.Layers.Combat.Squad
             Bot.Search.ToggleSearch(true, _enemy);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             if (!Bot.Mover.SprintController.Running) {
                 Shoot.CheckAimAndFire();

--- a/Layers/Combat/Squad/RegroupAction.cs
+++ b/Layers/Combat/Squad/RegroupAction.cs
@@ -19,7 +19,7 @@ namespace SAIN.Layers.Combat.Squad
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             var SquadLeadPos = Bot.Squad.LeaderComponent?.Position;
             if (SquadLeadPos != null) {

--- a/Layers/Combat/Squad/SuppressAction.cs
+++ b/Layers/Combat/Squad/SuppressAction.cs
@@ -21,7 +21,7 @@ namespace SAIN.Layers.Combat.Squad
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             var enemy = Bot.Enemy;
             if (enemy != null) {

--- a/Layers/Debug/CrawlAction.cs
+++ b/Layers/Debug/CrawlAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using SAIN.Helpers;
 using System.Collections;
 using System.Text;
@@ -18,7 +19,7 @@ namespace SAIN.Layers.Combat.Run
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             //Bot.Mover.SetTargetPose(1f);
             Bot.Mover.SetTargetMoveSpeed(1f);

--- a/Layers/Debug/RunningAction.cs
+++ b/Layers/Debug/RunningAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 using System.Collections;
 using System.Text;
 using UnityEngine;
@@ -17,7 +18,7 @@ namespace SAIN.Layers.Combat.Run
             ToggleAction(value);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Bot.Mover.SetTargetPose(1f);
             Bot.Mover.SetTargetMoveSpeed(1f);

--- a/Layers/DebugOverlay.cs
+++ b/Layers/DebugOverlay.cs
@@ -305,10 +305,10 @@ namespace SAIN.Layers
 
         private static float getPercentSpotted(Enemy enemy, out BodyPartType partType)
         {
-            float highestPercent = enemy.EnemyInfo.BodyData().Value?.PercentSpotted(out _) ?? 0f;
+            float highestPercent = enemy.EnemyInfo.BodyData().Value?.GetVisibilityLevel() ?? 0f;
             partType = BodyPartType.body;
             foreach (var part in enemy.EnemyInfo.AllActiveParts) {
-                float percent = part.Value.PercentSpotted(out _);
+                float percent = part.Value.GetVisibilityLevel();
                 if (percent > highestPercent) {
                     highestPercent = percent;
                     partType = part.Key.BodyPartType;

--- a/Layers/DebugOverlay.cs
+++ b/Layers/DebugOverlay.cs
@@ -135,12 +135,12 @@ namespace SAIN.Layers
                 }
 
                 if (debug.OverLay_AimInfo) {
-                    if (bot.BotOwner.AimingData != null) {
+                    if (bot.BotOwner.AimingManager.CurrentAiming != null) {
                         stringBuilder.AppendLine($"AimData: Status [{bot.Aim.AimStatus}] " +
                             $"Last Aim Time: [{bot.Aim.LastAimTime}] " +
-                            $"AimingTime [{timeAiming.GetValue(bot.BotOwner.AimingData)}] " +
-                            $"TimeToFnsh: [{TimeToAim.GetValue(bot.BotOwner.AimingData)}]");
-                        stringBuilder.AppendLine($"AimOffsetMagnitude [{((bot.BotOwner.AimingData.RealTargetPoint - bot.BotOwner.AimingData.EndTargetPoint).magnitude).Round100()}] " +
+                            $"AimingTime [{timeAiming.GetValue(bot.BotOwner.AimingManager.CurrentAiming)}] " +
+                            $"TimeToFnsh: [{TimeToAim.GetValue(bot.BotOwner.AimingManager.CurrentAiming)}]");
+                        stringBuilder.AppendLine($"AimOffsetMagnitude [{((bot.BotOwner.AimingManager.CurrentAiming.RealTargetPoint - bot.BotOwner.AimingManager.CurrentAiming.EndTargetPoint).magnitude).Round100()}] " +
                             $"Friendly Fire Status [{bot.FriendlyFire.FriendlyFireStatus}] " +
                             $"No Bush ESP Status: [{bot.NoBushESP.NoBushESPActive}]");
                         stringBuilder.AppendLine();

--- a/Layers/Extract/ExtractAction.cs
+++ b/Layers/Extract/ExtractAction.cs
@@ -1,4 +1,5 @@
 ﻿using Comfort.Common;
+using DrakiaXYZ.BigBrain.Brains;
 using EFT;
 using EFT.Interactive;
 using SAIN.Components;
@@ -40,7 +41,7 @@ namespace SAIN.Layers
             BotOwner.Mover.MovementResume();
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             float stamina = Bot.Player.Physical.Stamina.NormalValue;
             bool fightingEnemy = isFightingEnemy();

--- a/Layers/Flashbanged/ExtractAction.cs
+++ b/Layers/Flashbanged/ExtractAction.cs
@@ -1,4 +1,5 @@
-﻿using EFT;
+﻿using DrakiaXYZ.BigBrain.Brains;
+using EFT;
 
 namespace SAIN.Layers
 {
@@ -23,7 +24,7 @@ namespace SAIN.Layers
             Toggle(false);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
 
         }

--- a/Layers/Peace/Actions/ConversationAction.cs
+++ b/Layers/Peace/Actions/ConversationAction.cs
@@ -1,4 +1,5 @@
 ﻿using Comfort.Common;
+using DrakiaXYZ.BigBrain.Brains;
 using EFT;
 using SAIN.SAINComponent;
 
@@ -20,7 +21,7 @@ namespace SAIN.Layers.Peace
             Toggle(false);
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
         }
 

--- a/Layers/Unstuck/GetUnstuckAction.cs
+++ b/Layers/Unstuck/GetUnstuckAction.cs
@@ -19,7 +19,7 @@ namespace SAIN.Layers.Combat.Run
         {
         }
 
-        public override void Update()
+        public override void Update(CustomLayer.ActionData data)
         {
             Bot.Mover.SetTargetPose(1f);
             Bot.Mover.SetTargetMoveSpeed(1f);

--- a/Patches/AddBotComponentPatch.cs
+++ b/Patches/AddBotComponentPatch.cs
@@ -8,7 +8,7 @@ using SPT.Reflection.Patching;
 using System;
 using System.Reflection;
 using UnityEngine;
-using EFTSettingsLoadClass = GClass583;
+using EFTSettingsLoadClass = GClass598;
 
 namespace SAIN.Patches.Components
 {

--- a/Patches/GenericPatches.cs
+++ b/Patches/GenericPatches.cs
@@ -41,11 +41,11 @@ namespace SAIN.Patches.Generic
     {
         protected override MethodBase GetTargetMethod()
         {
-            return AccessTools.Method(typeof(GClass551), "SetEnvironment");
+            return AccessTools.Method(typeof(GClass567), "SetEnvironment");
         }
 
         [PatchPostfix]
-        public static void Patch(GClass551 __instance, IndoorTrigger trigger)
+        public static void Patch(GClass567 __instance, IndoorTrigger trigger)
         {
             SAINBotController.Instance?.PlayerEnviromentChanged(__instance?.Player?.ProfileId, trigger);
         }

--- a/Patches/GenericPatches.cs
+++ b/Patches/GenericPatches.cs
@@ -189,7 +189,7 @@ namespace SAIN.Patches.Generic
     {
         protected override MethodBase GetTargetMethod()
         {
-            return AccessTools.Method(typeof(BotsController), "method_4");
+            return AccessTools.Method(typeof(BotsController), "method_5");
         }
 
         [PatchPrefix]

--- a/Patches/HearingPatches.cs
+++ b/Patches/HearingPatches.cs
@@ -264,12 +264,12 @@ namespace SAIN.Patches.Hearing
 
 		protected override MethodBase GetTargetMethod()
 		{
-			AIFlareEnabled = AccessTools.Property(typeof(GClass551), "Boolean_0");
-			return AccessTools.Method(typeof(GClass551), "TryPlayShootSound");
+			AIFlareEnabled = AccessTools.Property(typeof(GClass567), "Boolean_0");
+			return AccessTools.Method(typeof(GClass567), "TryPlayShootSound");
 		}
 
 		[PatchPrefix]
-		public static bool PatchPrefix(GClass551 __instance)
+		public static bool PatchPrefix(GClass567 __instance)
 		{
 			//if (__instance.IsAI &&
 			//    SAINPlugin.IsBotExluded(__instance.BotOwner))

--- a/Patches/HearingPatches.cs
+++ b/Patches/HearingPatches.cs
@@ -434,7 +434,7 @@ namespace SAIN.Patches.Hearing
     {
         protected override MethodBase GetTargetMethod()
         {
-            return AccessTools.Method(typeof(Player), nameof(Player.method_55));
+            return AccessTools.Method(typeof(Player), nameof(Player.method_58));
         }
 
         [PatchPrefix]
@@ -466,7 +466,7 @@ namespace SAIN.Patches.Hearing
         protected override MethodBase GetTargetMethod()
         {
             return AccessTools.Method(typeof(Player), "SetInHands",
-                new[] { typeof(FoodDrinkItemClass), typeof(float), typeof(int), typeof(Callback<GInterface165>) });
+                new[] { typeof(FoodDrinkItemClass), typeof(float), typeof(int), typeof(Callback<GInterface176>) });
         }
 
         [PatchPrefix]
@@ -482,7 +482,7 @@ namespace SAIN.Patches.Hearing
         protected override MethodBase GetTargetMethod()
         {
             return AccessTools.Method(typeof(Player), "SetInHands",
-                new[] { typeof(MedsItemClass), typeof(EBodyPart), typeof(int), typeof(Callback<GInterface165>) });
+                new[] { typeof(MedsItemClass), typeof(EBodyPart), typeof(int), typeof(Callback<GInterface176>) });
         }
 
         [PatchPrefix]

--- a/Patches/HearingPatches.cs
+++ b/Patches/HearingPatches.cs
@@ -1,5 +1,6 @@
 ﻿using Audio.Data;
 using Comfort.Common;
+using CommonAssets.Scripts.Audio;
 using EFT;
 using EFT.Interactive;
 using EFT.InventoryLogic;

--- a/Patches/HearingPatches.cs
+++ b/Patches/HearingPatches.cs
@@ -150,7 +150,7 @@ namespace SAIN.Patches.Hearing
 
 		private static float calcVolume(Player player)
 		{
-			return player.MovementContext.CovertMovementVolumeBySpeed * player.method_54();
+			return player.MovementContext.CovertMovementVolumeBySpeed * player.method_54(player.MovementContext.ClampedSpeed);
 		}
 	}
 
@@ -177,7 +177,7 @@ namespace SAIN.Patches.Hearing
 					return false;
 				}
 
-				float volume = ____player.MovementContext.CovertMovementVolumeBySpeed * ____player.method_54();
+				float volume = ____player.MovementContext.CovertMovementVolumeBySpeed * ____player.method_54(____player.MovementContext.ClampedSpeed);
 				float baseRange = 60f;
 				SAINBotController.Instance?.BotHearing.PlayAISound(____player.ProfileId, SAINSoundType.Sprint, ____player.Position, baseRange, volume);
 			}

--- a/Patches/MovementPatches.cs
+++ b/Patches/MovementPatches.cs
@@ -6,7 +6,7 @@ using SAIN.Preset.GlobalSettings;
 using SPT.Reflection.Patching;
 using System.Reflection;
 using UnityEngine;
-using PathFinderClass = GClass470;
+using PathFinderClass = GClass485;
 
 namespace SAIN.Patches.Movement
 {

--- a/Patches/Shoot/AimDataPatches.cs
+++ b/Patches/Shoot/AimDataPatches.cs
@@ -15,7 +15,7 @@ using SPT.Reflection.Patching;
 using System.Reflection;
 using System.Text;
 using UnityEngine;
-using HitAffectClass = GClass568;
+using HitAffectClass = GClass583;
 
 namespace SAIN.Patches.Shoot.Aim
 {
@@ -125,10 +125,10 @@ namespace SAIN.Patches.Shoot.Aim
                 return true;
             }
 
-            Vector3 realTargetPoint = ___botOwner_0.AimingData.RealTargetPoint;
+            Vector3 realTargetPoint = ___botOwner_0.AimingManager.CurrentAiming.RealTargetPoint;
 
             if (bot.IsCheater) {
-                _endTargetPointProp.SetValue(___botOwner_0.AimingData, realTargetPoint);
+                _endTargetPointProp.SetValue(___botOwner_0.AimingManager.CurrentAiming, realTargetPoint);
                 return false;
             }
 
@@ -182,7 +182,7 @@ namespace SAIN.Patches.Shoot.Aim
             //    DebugGizmos.Line(recoilOffset + realTargetPoint, realTargetPoint, Color.red, 0.02f, true, 10f, true);
             //}
 
-            _endTargetPointProp.SetValue(___botOwner_0.AimingData, result);
+            _endTargetPointProp.SetValue(___botOwner_0.AimingManager.CurrentAiming, result);
             return false;
         }
 
@@ -267,7 +267,7 @@ namespace SAIN.Patches.Shoot.Aim
 
             float aimDelay = ___float_10;
             bool moving = ___bool_1;
-            bool panicing = (bool)_PanicingProp.GetValue(___botOwner_0.AimingData);
+            bool panicing = (bool)_PanicingProp.GetValue(___botOwner_0.AimingManager.CurrentAiming);
 
             __result = calculateAim(bot, dist, ang, moving, panicing, aimDelay);
             bot.Aim.LastAimTime = __result;

--- a/Patches/Shoot/AimDataPatches.cs
+++ b/Patches/Shoot/AimDataPatches.cs
@@ -437,7 +437,7 @@ namespace SAIN.Patches.Shoot.Aim
     {
         protected override MethodBase GetTargetMethod()
         {
-            return AccessTools.Method(typeof(EnemyInfo), "method_7");
+            return AccessTools.Method(typeof(EnemyInfo), "method_13");
         }
 
         [PatchPrefix]

--- a/Patches/Shoot/RateofFirePatch.cs
+++ b/Patches/Shoot/RateofFirePatch.cs
@@ -6,7 +6,7 @@ using SPT.Reflection.Patching;
 using System.Reflection;
 using UnityEngine;
 using static SAIN.Helpers.Shoot;
-using WeaponAIPresetManager = GClass440; // Contains property WeaponAIPreset
+using WeaponAIPresetManager = GClass453; // Contains property WeaponAIPreset
 
 namespace SAIN.Patches.Shoot.RateOfFire
 {
@@ -27,7 +27,7 @@ namespace SAIN.Patches.Shoot.RateOfFire
             {
                 return true;
             }
-            if (____owner.AimingData == null)
+            if (____owner.AimingManager.CurrentAiming == null)
             {
                 return true;
             }
@@ -36,7 +36,7 @@ namespace SAIN.Patches.Shoot.RateOfFire
 
             if (weapon.SelectedFireMode == Weapon.EFireMode.fullauto)
             {
-                float distance = ____owner.AimingData.LastDist2Target;
+                float distance = ____owner.AimingManager.CurrentAiming.LastDist2Target;
                 float scaledDistance = FullAutoBurstLength(____owner, distance);
 
                 ___nextFingerUpTime = scaledDistance + Time.time;

--- a/Patches/TalkPatches.cs
+++ b/Patches/TalkPatches.cs
@@ -40,7 +40,7 @@ namespace SAIN.Patches.Talk
     {
         protected override MethodBase GetTargetMethod()
         {
-            return AccessTools.Method(typeof(Player), nameof(Player.method_117));
+            return AccessTools.Method(typeof(Player), nameof(Player.method_110));
         }
 
         [PatchPrefix]

--- a/Patches/VisionPatches.cs
+++ b/Patches/VisionPatches.cs
@@ -462,7 +462,7 @@ namespace SAIN.Patches.Vision
 
         protected override MethodBase GetTargetMethod()
         {
-            _UsingLight = AccessTools.PropertySetter(typeof(GClass551), "UsingLight");
+            _UsingLight = AccessTools.PropertySetter(typeof(GClass567), "UsingLight");
             return AccessTools.Method(typeof(Player.FirearmController), "SetLightsState");
         }
 

--- a/Patches/VisionPatches.cs
+++ b/Patches/VisionPatches.cs
@@ -404,7 +404,7 @@ namespace SAIN.Patches.Vision
     {
         protected override MethodBase GetTargetMethod()
         {
-            return AccessTools.Method(typeof(EnemyInfo), "method_5");
+            return AccessTools.Method(typeof(EnemyInfo), "method_9");
         }
 
         [PatchPostfix]

--- a/Plugin/AssemblyInfoClass.cs
+++ b/Plugin/AssemblyInfoClass.cs
@@ -11,7 +11,7 @@
         public const string Trademark = "";
         public const string Culture = "";
 
-        public const int TarkovVersion = 33420;
+        public const int TarkovVersion = 35392;
 
         public const string EscapeFromTarkov = "EscapeFromTarkov.exe";
 
@@ -21,7 +21,7 @@
         public const string SAINPresetVersion = "3.2.0";
 
         public const string SPTGUID = "com.SPT.core";
-        public const string SPTVersion = "3.10.0";
+        public const string SPTVersion = "3.11.0";
 
         public const string WaypointsGUID = "xyz.drakia.waypoints";
         public const string WaypointsVersion = "1.6.0";

--- a/Plugin/SAINPlugin.cs
+++ b/Plugin/SAINPlugin.cs
@@ -141,7 +141,7 @@ namespace SAIN
                 typeof(Patches.Talk.BotTalkPatch),
                 typeof(Patches.Talk.BotTalkManualUpdatePatch),
 
-                typeof(Patches.Vision.DisableLookUpdatePatch),
+                //typeof(Patches.Vision.DisableLookUpdatePatch), // THIS BREAKS EVERYTHING
                 typeof(Patches.Vision.UpdateLightEnablePatch),
                 typeof(Patches.Vision.UpdateLightEnablePatch2),
                 typeof(Patches.Vision.ToggleNightVisionPatch),

--- a/Preset/GlobalSettings/Categories/PowerCalcSettings.cs
+++ b/Preset/GlobalSettings/Categories/PowerCalcSettings.cs
@@ -58,7 +58,7 @@ namespace SAIN.Preset.GlobalSettings
             power += RolePower(playerComponent.Player.Profile.Info.Settings.Role);
             power += ArmorPower(playerComponent.Player);
 
-			if (playerComponent.Player.AIData is GClass551 aiData)
+			if (playerComponent.Player.AIData is GClass567 aiData)
 			{
 				aiData.PowerOfEquipment = power;
 			}

--- a/ServerMod/package.json
+++ b/ServerMod/package.json
@@ -4,7 +4,7 @@
     "main": "src/mod.js",
     "license": "MIT",
     "author": "zSolarint",
-    "akiVersion": "~3.8",
+    "sptVersion": "~3.11",
     "scripts": {
         "setup": "npm i",
         "build": "node ./build.mjs",


### PR DESCRIPTION
I'm not at all familiar with this codebase but this should be mostly correct for what has changed with 3.11. I'm not expecting these changes to make SAIN ready to go but should help a little bit with getting it close to ready.

 `FootstepSoundPatch.calcVolume` calls `method_54` on `Player` but that's been changed to require a speed argument or it's no longer `method_54` but I don't have context or a copy of an older Assembly-CSharp to compare against to match signatures, I've inferred that it might be expecting `Player.MovementContext.ClampedSpeed` to be passed in so I've done that.

I also had to disable the `DisableLookUpdatePatch` patch because it was resulting in AI units ignoring everyone and not shooting or really reacting to anything.

Known errors to fix:

- [ ] AccessTools.Method: Could not find method for type EnemyInfo and name UpdatePartsByPriority and parameters
- [ ] AccessTools.Method: Could not find method for type EnemyInfo and name CheckVisibility and parameters
- [x] AccessTools.Property: Could not find property for type GClass551 and name UsingLight
- [x] Failed to patch float EnemyInfo::method_7(BotDifficultySettingsClass settings, IAIData enemyAiData, float personalLastSeenTime, UnityEngine.Vector3 personalLastSeenPos, float distanceToEnemyNormalized, float deltaTime): System.Exception: Parameter "withLegs" not found in method float EnemyInfo::method_7(BotDifficultySettingsClass settings, IAIData enemyAiData, float personalLastSeenTime, UnityEngine.Vector3 personalLastSeenPos, float distanceToEnemyNormalized, float deltaTime)