### PR TITLE
Interop Fixes [SPT 3.11]

### DIFF
--- a/Components/BotComponentSpace/Classes/Sense/Hearing/HearingInputClass.cs
+++ b/Components/BotComponentSpace/Classes/Sense/Hearing/HearingInputClass.cs
@@ -401,15 +401,19 @@ namespace SAIN.SAINComponent.Classes
 
         public bool SetIgnoreHearingExternal(bool value, bool ignoreUnderFire, float duration, out string reason)
         {
-            if (Bot.Enemy?.IsVisible == true)
+            // Only allow the bot to ignore hearing if it's not in combat
+            if (value)
             {
-                reason = "Enemy Visible";
-                return false;
-            }
-            if (BotOwner.Memory.IsUnderFire && !ignoreUnderFire)
-            {
-                reason = "Under Fire";
-                return false;
+                if (Bot.Enemy?.IsVisible == true)
+                {
+                    reason = "Enemy Visible";
+                    return false;
+                }
+                if (BotOwner.Memory.IsUnderFire && !ignoreUnderFire)
+                {
+                    reason = "Under Fire";
+                    return false;
+                }
             }
 
             IgnoreUnderFire = ignoreUnderFire;

--- a/Plugin/External.cs
+++ b/Plugin/External.cs
@@ -1,11 +1,9 @@
 ﻿using EFT;
-using HarmonyLib;
 using SAIN.Components;
 using SAIN.SAINComponent;
 using SAIN.SAINComponent.Classes;
 using SAIN.SAINComponent.Classes.EnemyClasses;
 using System.Collections.Generic;
-using System.Reflection;
 using UnityEngine;
 using UnityEngine.AI;
 
@@ -115,57 +113,6 @@ namespace SAIN.Plugin
         }
 
         private static bool DebugExternal => SAINPlugin.DebugSettings.Logs.DebugExternal;
-
-        public static bool ResetDecisionsForBot(BotOwner bot)
-        {
-            var component = GetBotComponent(bot);
-            if (component == null)
-            {
-                return false;
-            }
-
-            // Do not do anything if the bot is currently in combat
-            if (IsBotInCombat(component, out ECombatReason reason))
-            {
-                if (DebugExternal)
-                    Logger.LogInfo($"{bot.name} is currently engaging an enemy; cannot reset its decisions. Reason: [{reason}]");
-
-                return true;
-            }
-
-            if (IsBotSearching(component))
-            {
-                if (DebugExternal)
-                    Logger.LogInfo($"{bot.name} is currently searching and hasn't cleared last known position, cannot reset its decisions.");
-
-                return false;
-            }
-
-            if (DebugExternal)
-                Logger.LogInfo($"Forcing {bot.name} to reset its decisions...");
-
-            PropertyInfo enemyLastSeenTimeSenseProperty = AccessTools.Property(typeof(BotSettingsClass), "EnemyLastSeenTimeSense");
-            if (enemyLastSeenTimeSenseProperty == null)
-            {
-                Logger.LogError($"Could not reset EnemyLastSeenTimeSense for {bot.name}'s enemies");
-                return false;
-            }
-
-            // Force the bot to think it has not seen any enemies in a long time
-            foreach (IPlayer player in bot.BotsGroup.Enemies.Keys)
-            {
-                bot.BotsGroup.Enemies[player].Clear();
-                enemyLastSeenTimeSenseProperty.SetValue(bot.BotsGroup.Enemies[player], 1);
-            }
-
-            // Force the bot to "forget" what it was doing
-            bot.Memory.GoalTarget.Clear();
-            bot.Memory.GoalEnemy = null;
-            component.EnemyController.ClearEnemy();
-            component.Decision.ResetDecisions(true);
-
-            return true;
-        }
 
         public static float TimeSinceSenseEnemy(BotOwner botOwner)
         {

--- a/Plugin/SAINInterop.cs
+++ b/Plugin/SAINInterop.cs
@@ -20,7 +20,6 @@ namespace SAIN.Plugin
 
         private static MethodInfo _ExtractBotMethod;
         private static MethodInfo _SetExfilForBotMethod;
-        private static MethodInfo _ResetDecisionsForBotMethod;
         private static MethodInfo _IsPathTowardEnemyMethod;
         private static MethodInfo _TimeSinceSenseEnemyMethod;
         private static MethodInfo _CanBotQuestMethod;
@@ -63,7 +62,6 @@ namespace SAIN.Plugin
                 {
                     _ExtractBotMethod = AccessTools.Method(_SAINExternalType, "ExtractBot");
                     _SetExfilForBotMethod = AccessTools.Method(_SAINExternalType, "TrySetExfilForBot");
-                    _ResetDecisionsForBotMethod = AccessTools.Method(_SAINExternalType, "ResetDecisionsForBot");
                     _IsPathTowardEnemyMethod = AccessTools.Method(_SAINExternalType, "IsPathTowardEnemy");
                     _TimeSinceSenseEnemyMethod = AccessTools.Method(_SAINExternalType, "TimeSinceSenseEnemy");
                     _CanBotQuestMethod = AccessTools.Method(_SAINExternalType, "CanBotQuest");
@@ -161,17 +159,6 @@ namespace SAIN.Plugin
             if (_SetExfilForBotMethod == null) return false;
 
             return (bool)_SetExfilForBotMethod.Invoke(null, [botOwner]);
-        }
-
-        /**
-         * Force a bot to reset its decisions if SAIN is loaded. Return true if successful.
-         */
-        public static bool TryResetDecisionsForBot(BotOwner botOwner)
-        {
-            if (!Init()) return false;
-            if (_ResetDecisionsForBotMethod == null) return false;
-
-            return (bool)_ResetDecisionsForBotMethod.Invoke(null, [botOwner]);
         }
 
         /// <summary>


### PR DESCRIPTION
Made the following changes:
* When `SetIgnoreHearingExternal` is called, only check if the bot has a visible enemy or is under fire if the desired value is true
* Removed `ResetDecisionsForBot` interop method because it's obsolete and hasn't been maintained in about a year