### PR TITLE
Extraction Fix for V4

### DIFF
--- a/Classes/Bot/Mover/BotPathFollowerClass.cs
+++ b/Classes/Bot/Mover/BotPathFollowerClass.cs
@@ -1,5 +1,4 @@
 ﻿using EFT;
-using Mono.Cecil;
 using SAIN.Components;
 using SAIN.Components.PlayerComponentSpace.PersonClasses;
 using SAIN.Helpers;

--- a/Classes/Bot/Mover/BotPathFollowerClass.cs
+++ b/Classes/Bot/Mover/BotPathFollowerClass.cs
@@ -1,4 +1,5 @@
 ﻿using EFT;
+using Mono.Cecil;
 using SAIN.Components;
 using SAIN.Components.PlayerComponentSpace.PersonClasses;
 using SAIN.Helpers;
@@ -73,7 +74,7 @@ namespace SAIN.SAINComponent.Classes.Mover
             }
         }
 
-        public bool RunToPoint(Vector3 point, ESprintUrgency urgency, bool stopSprintEnemyVisible, bool checkSameWay = true, System.Action callback = null)
+        public bool RunToPoint(Vector3 point, ESprintUrgency urgency, bool stopSprintEnemyVisible, bool checkSameWay = true, bool mustHaveCompletePath = true, System.Action callback = null)
         {
             if (checkSameWay && TryUpdatePath(point, true))
             {
@@ -81,7 +82,7 @@ namespace SAIN.SAINComponent.Classes.Mover
                 return true;
             }
 
-            if (Bot.Mover.CanGoToPoint(point, out NavMeshPath path))
+            if (Bot.Mover.CanGoToPoint(point, out NavMeshPath path, mustHaveCompletePath))
             {
                 TriggerNewMove(path.corners, point, true, urgency, callback);
                 _moveData.ShallStopSprintWhenSeeEnemy = stopSprintEnemyVisible;
@@ -112,15 +113,16 @@ namespace SAIN.SAINComponent.Classes.Mover
             return RunToPointByWay(way?.corners, urgency, stopSprintEnemyVisible, checkSameWay, callback);
         }
 
-        public bool WalkToPoint(Vector3 point, bool checkSameWay = true, System.Action callback = null)
+        public bool WalkToPoint(Vector3 point, bool checkSameWay = true, bool mustHaveCompletePath = true, System.Action callback = null)
         {
             if (checkSameWay && TryUpdatePath(point, false))
             {
                 return true;
             }
-            if (Bot.Mover.CanGoToPoint(point, out NavMeshPath path))
+            if (Bot.Mover.CanGoToPoint(point, out NavMeshPath path, mustHaveCompletePath))
             {
                 TriggerNewMove(path.corners, point, false, ESprintUrgency.None, callback);
+                return true;
             }
             return false;
         }

--- a/Classes/Bot/Mover/IBotMoveData.cs
+++ b/Classes/Bot/Mover/IBotMoveData.cs
@@ -18,6 +18,7 @@ namespace SAIN.SAINComponent.Classes.Mover
         public bool OnLastCorner { get; }
         public float CurrentCornerDistanceSqr { get; }
         public BotCornerDetails CurrentCorner { get; }
+        public BotCornerDetails LastCorner { get; }
         public bool WantToSprint { get; }
         public bool ShallSprintNow { get; }
         public bool ShallStopSprintWhenSeeEnemy { get; }

--- a/Classes/Bot/Mover/SAINMoverClass.cs
+++ b/Classes/Bot/Mover/SAINMoverClass.cs
@@ -159,7 +159,7 @@ namespace SAIN.SAINComponent.Classes.Mover
         public bool GoToPoint(Vector3 point, out bool calculating, float reachDist = -1f, bool crawl = false, bool slowAtEnd = true, bool mustHaveCompletePath = true)
         {
             calculating = false;
-            if (PathFollower.WalkToPoint(point, true))
+            if (PathFollower.WalkToPoint(point, true, mustHaveCompletePath))
             {
                 CurrentPathStatus = NavMeshPathStatus.PathComplete;
                 Crawling = crawl && Bot.Info.FileSettings.Move.PRONE_TOGGLE && GlobalSettingsClass.Instance.Move.PRONE_TOGGLE;
@@ -172,7 +172,7 @@ namespace SAIN.SAINComponent.Classes.Mover
 
         public bool RunToPoint(Vector3 point, ESprintUrgency urgency, bool stopSprintEnemyVisible, bool checkSameWay = true, bool mustHaveCompletePath = true)
         {
-            if (PathFollower.RunToPoint(point, urgency, stopSprintEnemyVisible, checkSameWay))
+            if (PathFollower.RunToPoint(point, urgency, stopSprintEnemyVisible, checkSameWay, mustHaveCompletePath))
             {
                 CurrentPathStatus = NavMeshPathStatus.PathComplete;
                 Crawling = false;
@@ -255,6 +255,11 @@ namespace SAIN.SAINComponent.Classes.Mover
                 path = new NavMeshPath();
                 if (NavMesh.CalculatePath(botHit.position, targetHit.position, -1, path) && path.corners.Length > 1)
                 {
+                    if (path.status == NavMeshPathStatus.PathInvalid)
+                    {
+                        return false;
+                    }
+
                     if (mustHaveCompletePath
                         && path.status != NavMeshPathStatus.PathComplete)
                     {

--- a/Classes/Bot/WeaponFunction/ShootDeciderClass.cs
+++ b/Classes/Bot/WeaponFunction/ShootDeciderClass.cs
@@ -76,6 +76,12 @@ namespace SAIN.SAINComponent.Classes
         
         public Enemy GetEnemyToShoot(Enemy priorityEnemy = null)
         {
+            if (priorityEnemy == null)
+            {
+                Bot.Aim.LoseAimTarget();
+                return null;
+            }
+
             if (AimAndShootAtEnemy(priorityEnemy, Bot))
             {
                 UpdateADS(priorityEnemy);

--- a/Layers/BotAction.cs
+++ b/Layers/BotAction.cs
@@ -37,6 +37,11 @@ namespace SAIN.Layers
         {
             get
             {
+                if (BotOwner == null)
+                {
+                    return null;
+                }
+
                 if (_bot == null &&
                     BotManagerComponent.Instance.GetSAIN(BotOwner, out var bot))
                 {

--- a/Layers/Extract/ExtractAction.cs
+++ b/Layers/Extract/ExtractAction.cs
@@ -9,7 +9,6 @@ using SAIN.SAINComponent.Classes.Memory;
 using Systems.Effects;
 using UnityEngine;
 using UnityEngine.AI;
-using UnityEngine.UIElements;
 
 namespace SAIN.Layers
 {

--- a/Layers/Extract/ExtractAction.cs
+++ b/Layers/Extract/ExtractAction.cs
@@ -4,10 +4,12 @@ using EFT;
 using EFT.Interactive;
 using SAIN.Components;
 using SAIN.Components.BotController;
+using SAIN.SAINComponent.Classes.EnemyClasses;
 using SAIN.SAINComponent.Classes.Memory;
 using Systems.Effects;
 using UnityEngine;
 using UnityEngine.AI;
+using UnityEngine.UIElements;
 
 namespace SAIN.Layers
 {
@@ -42,43 +44,12 @@ namespace SAIN.Layers
         public override void Update(CustomLayer.ActionData data)
         {
             this.StartProfilingSample("Update");
-            float stamina = Bot.Player.Physical.Stamina.NormalValue;
+
             bool fightingEnemy = IsFightingEnemy();
-            // Environment id of 0 means a bot is outside.
-            if (Bot.Player.AIData.EnvironmentId != 0)
-            {
-                shallSprint = false;
-            }
-            else if (fightingEnemy)
-            {
-                shallSprint = false;
-            }
-            else if (stamina > 0.75f)
-            {
-                shallSprint = true;
-            }
-            else if (stamina < 0.2f)
-            {
-                shallSprint = false;
-            }
-
-            if (!BotOwner.GetPlayer.MovementContext.CanSprint)
-            {
-                shallSprint = false;
-            }
-
-            if (!Exfil.HasValue)
-            {
-                return;
-            }
+            updateShallSprint(fightingEnemy);
 
             Vector3 point = Exfil.Value;
-            float distance = (point - BotOwner.Position).sqrMagnitude;
-
-            if (distance < 8f)
-            {
-                shallSprint = false;
-            }
+            float distance = (Exfil.Value - BotOwner.Position).sqrMagnitude;
 
             if (ExtractStarted)
             {
@@ -107,8 +78,8 @@ namespace SAIN.Layers
                 Bot.Mover.SetTargetMoveSpeed(1f);
             }
 
-            Shoot.ShootAnyVisibleEnemies(Bot.Enemy);
-            Bot.Steering.SteerByPriority(Bot.Enemy);
+            updateSteering();
+
             this.EndProfilingSample();
         }
 
@@ -128,6 +99,63 @@ namespace SAIN.Layers
 
         private bool shallSprint;
 
+        private void updateShallSprint(bool fightingEnemy)
+        {
+            float stamina = Bot.Player.Physical.Stamina.NormalValue;
+            
+            // Environment id of 0 means a bot is outside.
+            if (Bot.Player.AIData.EnvironmentId != 0)
+            {
+                shallSprint = false;
+            }
+            else if (fightingEnemy)
+            {
+                shallSprint = false;
+            }
+            else if (stamina > 0.75f)
+            {
+                shallSprint = true;
+            }
+            else if (stamina < 0.2f)
+            {
+                shallSprint = false;
+            }
+
+            if (!BotOwner.GetPlayer.MovementContext.CanSprint)
+            {
+                shallSprint = false;
+            }
+
+            if (!Exfil.HasValue)
+            {
+                return;
+            }
+
+            float distance = (Exfil.Value - BotOwner.Position).sqrMagnitude;
+
+            if (distance < 8f)
+            {
+                shallSprint = false;
+            }
+        }
+
+        private void updateSteering()
+        {
+            Enemy Enemy = Bot.Enemy;
+
+            if (Shoot.ShootAnyVisibleEnemies(Enemy) || Bot.Suppression.TrySuppressEnemy(Enemy))
+            {
+                return;
+            }
+
+            if (Bot.Steering.SteerByPriority(Enemy))
+            {
+                return;
+            }
+
+            Bot.Steering.LookToMovingDirection();
+        }
+
         private void MoveToExtract(float distance, Vector3 point)
         {
             if (BotOwner.Mover == null)
@@ -135,7 +163,12 @@ namespace SAIN.Layers
                 return;
             }
 
-            Bot.Mover.Sprint(shallSprint);
+            if (ExtractStarted)
+            {
+                return;
+            }
+
+            ReCalcPath(point);
 
             if (distance > MinDistanceToStartExtract * 2)
             {
@@ -145,35 +178,53 @@ namespace SAIN.Layers
             {
                 ExtractStarted = true;
             }
+        }
 
-            if (ExtractStarted)
+        private void ReCalcPath(Vector3 point)
+        {
+            if (ReCalcPathTimer > Time.time)
             {
                 return;
             }
 
-            if (ReCalcPathTimer < Time.time)
+            ExtractTimer = -1f;
+            ReCalcPathTimer = Time.time + 4f;
+
+            Bot.Memory.Extract.ExtractStatus = EExtractStatus.MovingTo;
+
+            if (shallSprint)
             {
-                ExtractTimer = -1f;
-                ReCalcPathTimer = Time.time + 4f;
+                Bot.Mover.RunToPoint(point, SAINComponent.Classes.Mover.ESprintUrgency.Low, true, true, false);
+            }
+            else
+            {
+                Bot.Mover.GoToPoint(point, out bool calculating, -1, false, true, false);
+            }
 
-                Bot.Memory.Extract.ExtractStatus = EExtractStatus.MovingTo;
-                NavMeshPathStatus pathStatus = BotOwner.Mover.GoToPoint(point, true, 0.5f, false, false);
-                var pathController = BotOwner.Mover._pathController;
-                if (pathController?.CurPath != null)
+            Vector3 lastCornerPoint = Bot.Mover.PathFollower.MoveData.LastCorner.Position;
+            if (lastCornerPoint == null)
+            {
+                Logger.LogError($"{BotOwner.name} has no last corner point in path. Cannot recalculate extract path.");
+                return;
+            }
+
+            NavMeshPathStatus pathStatus = Bot.Mover.CurrentPathStatus;
+            float distanceToEndOfPath = Vector3.Distance(BotOwner.Position, lastCornerPoint);
+            bool reachedEndOfIncompletePath = (pathStatus == NavMeshPathStatus.PathPartial) && (distanceToEndOfPath < BotExtractManager.MinDistanceToExtract);
+
+            // If the path to the extract is invalid or the path is incomplete and the bot reached the end of it, select a new extract
+            if ((pathStatus == NavMeshPathStatus.PathInvalid) || reachedEndOfIncompletePath)
+            {
+                if (SAINPlugin.DebugSettings.Logs.DebugExtract)
                 {
-                    float distanceToEndOfPath = Vector3.Distance(BotOwner.Position, pathController.CurPath.LastCorner());
-                    bool reachedEndOfIncompletePath = (pathStatus == NavMeshPathStatus.PathPartial) && (distanceToEndOfPath < BotExtractManager.MinDistanceToExtract);
-
-                    // If the path to the extract is invalid or the path is incomplete and the bot reached the end of it, select a new extract
-                    if ((pathStatus == NavMeshPathStatus.PathInvalid) || reachedEndOfIncompletePath)
-                    {
-                        // Need to reset the search timer to prevent the bot from immediately selecting (possibly) the same extract
-                        BotManagerComponent.Instance.BotExtractManager.ResetExfilSearchTime(Bot);
-
-                        Bot.Memory.Extract.ExfilPoint = null;
-                        Bot.Memory.Extract.ExfilPosition = null;
-                    }
+                    Logger.LogWarning($"{BotOwner.name} has an invalid or incomplete path to extract. Status={pathStatus}, DistanceToEOP={distanceToEndOfPath}");
                 }
+
+                // Need to reset the search timer to prevent the bot from immediately selecting (possibly) the same extract
+                BotManagerComponent.Instance.BotExtractManager.ResetExfilSearchTime(Bot);
+
+                Bot.Memory.Extract.ExfilPoint = null;
+                Bot.Memory.Extract.ExfilPosition = null;
             }
         }
 


### PR DESCRIPTION
**Main Purpose:** Fix bots not extracting after SAIN's internal pathfinder was added in V4.

**Additional fixes:**
* Fixed `BotPathFollowerClass.WalkToPoint()` not returning `true` if `Bot.Mover.CanGoToPoint()` returns `true` (which is the case with `RunToPoint()`)
* Expose `mustHaveCompletePath` as an argument in `WalkToPoint()` and `RunToPoint()`
* Fixed NRE spam for `GetEnemyToShoot()` if `priorityEnemy == null`
* Fixed `BotComponent.Bot` NRE if `BotOwner == null`
* Applied new bot steering system within `ExtractAction`

**TODO:**
* There is still an NRE for one frame in `ExtractAction.Update()` right when bots extract, but it doesn't seem to cause any problems. It's also only visible when using the debug build of BigBrain. 